### PR TITLE
253/Window Focus Detection

### DIFF
--- a/src/lib/hooks/useWindowUnfocused.ts
+++ b/src/lib/hooks/useWindowUnfocused.ts
@@ -1,39 +1,39 @@
 'use client';
 
-import { useEffect, useState } from "react";
+import { useEffect, useState } from 'react';
 
 export function useWindowUnfocused(): boolean {
-  const [isWindowUnfocused, setIsWindowUnfocused] = useState(false);
+    const [isWindowUnfocused, setIsWindowUnfocused] = useState(false);
 
-  useEffect(() => {
-    const getIsUnfocused = () => {
-      return document.hidden || !document.hasFocus();
-    };
+    useEffect(() => {
+        const getIsUnfocused = () => {
+            return document.hidden || !document.hasFocus();
+        };
 
-    const handleFocus = () => {
-      setIsWindowUnfocused(getIsUnfocused());
-    };
+        const handleFocus = () => {
+            setIsWindowUnfocused(getIsUnfocused());
+        };
 
-    const handleBlur = () => {
-      setIsWindowUnfocused(true);
-    };
+        const handleBlur = () => {
+            setIsWindowUnfocused(true);
+        };
 
-    const handleVisibilityChange = () => {
-      setIsWindowUnfocused(getIsUnfocused());
-    };
+        const handleVisibilityChange = () => {
+            setIsWindowUnfocused(getIsUnfocused());
+        };
 
-    setIsWindowUnfocused(getIsUnfocused());
+        setIsWindowUnfocused(getIsUnfocused());
 
-    window.addEventListener("focus", handleFocus);
-    window.addEventListener("blur", handleBlur);
-    document.addEventListener("visibilitychange", handleVisibilityChange);
+        window.addEventListener('focus', handleFocus);
+        window.addEventListener('blur', handleBlur);
+        document.addEventListener('visibilitychange', handleVisibilityChange);
 
-    return () => {
-      window.removeEventListener("focus", handleFocus);
-      window.removeEventListener("blur", handleBlur);
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
-  }, []);
+        return () => {
+            window.removeEventListener('focus', handleFocus);
+            window.removeEventListener('blur', handleBlur);
+            document.removeEventListener('visibilitychange', handleVisibilityChange);
+        };
+    }, []);
 
-  return isWindowUnfocused;
+    return isWindowUnfocused;
 }


### PR DESCRIPTION
# Window Focus Detection

## Changes

Added a new custom hook `useWindowUnfocused` that detects if a user is focused on this tab/window. Uses event listeners for window focus/blur and document visibility change. Unfocused is true if window is blurred or document is hidden.

---

## Notes

Tested with a throwaway page that rendered focused vs. unfocused and console logged when the page was not focused and then returned back into focus. Tested with switching tabs, switching windows, having two windows open with split screen but being clicked onto the other window, and cmd+tab. 

---

## Checklist

Please go through all items before requesting reviewers:

- [x] All commits are tagged with the ticket number
- [ ] No linting errors / newline warnings
- [x] All code follows repository-configured formatting
- [x] No merge conflicts
- [ ] All checks passing
- [x] Screenshots included for UI changes
- [x] Remove non-applicable sections of this template
- [x] PR assigned to yourself
- [ ] Reviewers requested & Slack ping sent
- [x] PR linked to the issue (fill in 'Closes #')
- [x] If design-related, notify the designer in Slack

---

## Closes

Closes #253 
