### PR TITLE
275/Assessment Intro and Outro

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,8 @@ services:
         build:
             context: ./src/ws/
             dockerfile: Dockerfile
+        env_file:
+            - .env
         ports:
             - 8080:8080
         volumes:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "dev:migrate": "npx prisma migrate dev",
         "dev:start": "next dev",
+        "dev:ws": "node --env-file .env src/ws/index.js",
         "dev": "npm run dev:migrate && npm run dev:start",
         "build": "prisma generate && next build",
         "start": "next start",

--- a/prisma/migrations/20260412020911_remove_unique_link/migration.sql
+++ b/prisma/migrations/20260412020911_remove_unique_link/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `uniqueLink` on the `Assessment` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "public"."Assessment_uniqueLink_key";
+
+-- AlterTable
+ALTER TABLE "public"."Assessment" DROP COLUMN "uniqueLink";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -224,7 +224,6 @@ model Assessment {
   assessmentTemplateId String
   assignedAt           DateTime  @default(now())
   submittedAt          DateTime?
-  uniqueLink           String    @unique
   deadline             DateTime?
 
   application        Application        @relation(fields: [applicationId], references: [id], onDelete: Cascade)

--- a/prisma/seed-data/assessment.seed.ts
+++ b/prisma/seed-data/assessment.seed.ts
@@ -2,13 +2,11 @@ export const assessmentsData = [
     {
         id: 'assessment_carter_001',
         assessmentTemplateId: 'assessment_template_general_001',
-        uniqueLink: 'https://assessment.sarge.dev/take/carter-herman-001',
         deadline: new Date('2035-12-20T23:59:59Z'),
     },
     {
         id: 'assessment_laith_001',
         assessmentTemplateId: 'assessment_template_general_001',
-        uniqueLink: 'https://assessment.sarge.dev/take/laith-taher-001',
         deadline: new Date('2035-12-20T23:59:59Z'),
     },
 ];

--- a/prisma/seed-data/languages.seed.ts
+++ b/prisma/seed-data/languages.seed.ts
@@ -9,7 +9,17 @@ export const languageData = [
     :type target: int
     :rtype: List[int]
     """
-    pass`,
+    pass
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    nums = list(map(int, _lines[0].split()))
+    target = int(_lines[1])
+    result = two_sum(nums, target)
+    print(' '.join(str(x) for x in result))`,
         solution: `def two_sum(nums, target):
     """
     :type nums: List[int]
@@ -22,7 +32,17 @@ export const languageData = [
         if complement in seen:
             return [seen[complement], i]
         seen[num] = i
-    return []`,
+    return []
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    nums = list(map(int, _lines[0].split()))
+    target = int(_lines[1])
+    result = two_sum(nums, target)
+    print(' '.join(str(x) for x in result))`,
     },
     // Two Sum - JavaScript
     {
@@ -35,7 +55,14 @@ export const languageData = [
  */
 function twoSum(nums, target) {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const nums = _lines[0].split(' ').map(Number);
+const target = Number(_lines[1]);
+const result = twoSum(nums, target);
+console.log(result.join(' '));`,
         solution: `/**
  * @param {number[]} nums
  * @param {number} target
@@ -51,7 +78,14 @@ function twoSum(nums, target) {
         seen.set(nums[i], i);
     }
     return [];
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const nums = _lines[0].split(' ').map(Number);
+const target = Number(_lines[1]);
+const result = twoSum(nums, target);
+console.log(result.join(' '));`,
     },
     // Two Sum - TypeScript
     {
@@ -59,7 +93,14 @@ function twoSum(nums, target) {
         language: 'typescript',
         stub: `function twoSum(nums: number[], target: number): number[] {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const nums: number[] = _lines[0].split(' ').map(Number);
+const target: number = Number(_lines[1]);
+const result = twoSum(nums, target);
+console.log(result.join(' '));`,
         solution: `function twoSum(nums: number[], target: number): number[] {
     const seen = new Map<number, number>();
     for (let i = 0; i < nums.length; i++) {
@@ -70,7 +111,14 @@ function twoSum(nums, target) {
         seen.set(nums[i], i);
     }
     return [];
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const nums: number[] = _lines[0].split(' ').map(Number);
+const target: number = Number(_lines[1]);
+const result = twoSum(nums, target);
+console.log(result.join(' '));`,
     },
 
     // Reverse String - Python
@@ -82,7 +130,16 @@ function twoSum(nums, target) {
     :type s: List[str]
     :rtype: None Do not return anything, modify s in-place instead.
     """
-    pass`,
+    pass
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    s = _lines[0].split()
+    reverse_string(s)
+    print(' '.join(s))`,
         solution: `def reverse_string(s):
     """
     :type s: List[str]
@@ -92,7 +149,16 @@ function twoSum(nums, target) {
     while left < right:
         s[left], s[right] = s[right], s[left]
         left += 1
-        right -= 1`,
+        right -= 1
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    s = _lines[0].split()
+    reverse_string(s)
+    print(' '.join(s))`,
     },
     // Reverse String - JavaScript
     {
@@ -104,7 +170,13 @@ function twoSum(nums, target) {
  */
 function reverseString(s) {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const s = _lines[0].split(' ');
+reverseString(s);
+console.log(s.join(' '));`,
         solution: `/**
  * @param {character[]} s
  * @return {void} Do not return anything, modify s in-place instead.
@@ -116,7 +188,13 @@ function reverseString(s) {
         left++;
         right--;
     }
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const s = _lines[0].split(' ');
+reverseString(s);
+console.log(s.join(' '));`,
     },
     // Reverse String - TypeScript
     {
@@ -124,7 +202,13 @@ function reverseString(s) {
         language: 'typescript',
         stub: `function reverseString(s: string[]): void {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const s: string[] = _lines[0].split(' ');
+reverseString(s);
+console.log(s.join(' '));`,
         solution: `function reverseString(s: string[]): void {
     let left = 0, right = s.length - 1;
     while (left < right) {
@@ -132,7 +216,13 @@ function reverseString(s) {
         left++;
         right--;
     }
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const s: string[] = _lines[0].split(' ');
+reverseString(s);
+console.log(s.join(' '));`,
     },
 
     // Valid Palindrome - Python
@@ -144,14 +234,32 @@ function reverseString(s) {
     :type s: str
     :rtype: bool
     """
-    pass`,
+    pass
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    s = _lines[0]
+    result = is_palindrome(s)
+    print(str(result).lower())`,
         solution: `def is_palindrome(s):
     """
     :type s: str
     :rtype: bool
     """
     cleaned = ''.join(c.lower() for c in s if c.isalnum())
-    return cleaned == cleaned[::-1]`,
+    return cleaned == cleaned[::-1]
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    s = _lines[0]
+    result = is_palindrome(s)
+    print(str(result).lower())`,
     },
     // Valid Palindrome - JavaScript
     {
@@ -163,7 +271,13 @@ function reverseString(s) {
  */
 function isPalindrome(s) {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const s = _lines[0];
+const result = isPalindrome(s);
+console.log(JSON.stringify(result));`,
         solution: `/**
  * @param {string} s
  * @return {boolean}
@@ -171,7 +285,13 @@ function isPalindrome(s) {
 function isPalindrome(s) {
     const cleaned = s.toLowerCase().replace(/[^a-z0-9]/g, '');
     return cleaned === cleaned.split('').reverse().join('');
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const s = _lines[0];
+const result = isPalindrome(s);
+console.log(JSON.stringify(result));`,
     },
     // Valid Palindrome - TypeScript
     {
@@ -179,64 +299,118 @@ function isPalindrome(s) {
         language: 'typescript',
         stub: `function isPalindrome(s: string): boolean {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const s: string = _lines[0];
+const result = isPalindrome(s);
+console.log(JSON.stringify(result));`,
         solution: `function isPalindrome(s: string): boolean {
     const cleaned = s.toLowerCase().replace(/[^a-z0-9]/g, '');
     return cleaned === cleaned.split('').reverse().join('');
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const s: string = _lines[0];
+const result = isPalindrome(s);
+console.log(JSON.stringify(result));`,
     },
 
     // FizzBuzz - Python
     {
         taskTemplateId: 'task_template_fizzbuzz_001',
         language: 'python',
-        stub: `# Write your FizzBuzz solution here
-`,
-        solution: `for i in range(1, 101):
-    if i % 15 == 0:
-        print("FizzBuzz")
-    elif i % 3 == 0:
-        print("Fizz")
-    elif i % 5 == 0:
-        print("Buzz")
+        stub: `def fizzbuzz(n: int) -> str:
+    pass
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    n = int(_lines[0])
+    result = fizzbuzz(n)
+    print(result)`,
+        solution: `def fizzbuzz(n: int) -> str:
+    if n % 15 == 0:
+        return "FizzBuzz"
+    elif n % 3 == 0:
+        return "Fizz"
+    elif n % 5 == 0:
+        return "Buzz"
     else:
-        print(i)`,
+        return str(n)
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    n = int(_lines[0])
+    result = fizzbuzz(n)
+    print(result)`,
     },
     // FizzBuzz - JavaScript
     {
         taskTemplateId: 'task_template_fizzbuzz_001',
         language: 'javascript',
-        stub: `// Write your FizzBuzz solution here
-`,
-        solution: `for (let i = 1; i <= 100; i++) {
-    if (i % 15 === 0) {
-        console.log("FizzBuzz");
-    } else if (i % 3 === 0) {
-        console.log("Fizz");
-    } else if (i % 5 === 0) {
-        console.log("Buzz");
-    } else {
-        console.log(i);
-    }
-}`,
+        stub: `/**
+ * @param {number} n
+ * @return {string}
+ */
+function fizzBuzz(n) {
+    // Your code here
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const n = Number(_lines[0]);
+const result = fizzBuzz(n);
+console.log(result);`,
+        solution: `/**
+ * @param {number} n
+ * @return {string}
+ */
+function fizzBuzz(n) {
+    if (n % 15 === 0) return 'FizzBuzz';
+    if (n % 3 === 0) return 'Fizz';
+    if (n % 5 === 0) return 'Buzz';
+    return String(n);
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const n = Number(_lines[0]);
+const result = fizzBuzz(n);
+console.log(result);`,
     },
     // FizzBuzz - TypeScript
     {
         taskTemplateId: 'task_template_fizzbuzz_001',
         language: 'typescript',
-        stub: `// Write your FizzBuzz solution here
-`,
-        solution: `for (let i = 1; i <= 100; i++) {
-    if (i % 15 === 0) {
-        console.log("FizzBuzz");
-    } else if (i % 3 === 0) {
-        console.log("Fizz");
-    } else if (i % 5 === 0) {
-        console.log("Buzz");
-    } else {
-        console.log(i);
-    }
-}`,
+        stub: `function fizzBuzz(n: number): string {
+    // Your code here
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const n: number = Number(_lines[0]);
+const result = fizzBuzz(n);
+console.log(result);`,
+        solution: `function fizzBuzz(n: number): string {
+    if (n % 15 === 0) return 'FizzBuzz';
+    if (n % 3 === 0) return 'Fizz';
+    if (n % 5 === 0) return 'Buzz';
+    return String(n);
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const n: number = Number(_lines[0]);
+const result = fizzBuzz(n);
+console.log(result);`,
     },
 
     // Quick Warmup - Python
@@ -276,7 +450,16 @@ console.log("Hello, World!");`,
     :type nums: List[int]
     :rtype: int
     """
-    pass`,
+    pass
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    nums = list(map(int, _lines[0].split()))
+    result = max_subarray(nums)
+    print(result)`,
         solution: `def max_subarray(nums):
     """
     :type nums: List[int]
@@ -286,7 +469,16 @@ console.log("Hello, World!");`,
     for num in nums[1:]:
         current_sum = max(num, current_sum + num)
         max_sum = max(max_sum, current_sum)
-    return max_sum`,
+    return max_sum
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    nums = list(map(int, _lines[0].split()))
+    result = max_subarray(nums)
+    print(result)`,
     },
     // Maximum Subarray - JavaScript
     {
@@ -298,7 +490,13 @@ console.log("Hello, World!");`,
  */
 function maxSubArray(nums) {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const nums = _lines[0].split(' ').map(Number);
+const result = maxSubArray(nums);
+console.log(result);`,
         solution: `/**
  * @param {number[]} nums
  * @return {number}
@@ -313,7 +511,13 @@ function maxSubArray(nums) {
     }
 
     return maxSum;
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const nums = _lines[0].split(' ').map(Number);
+const result = maxSubArray(nums);
+console.log(result);`,
     },
     // Maximum Subarray - TypeScript
     {
@@ -321,7 +525,13 @@ function maxSubArray(nums) {
         language: 'typescript',
         stub: `function maxSubArray(nums: number[]): number {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const nums: number[] = _lines[0].split(' ').map(Number);
+const result = maxSubArray(nums);
+console.log(result);`,
         solution: `function maxSubArray(nums: number[]): number {
     let maxSum = nums[0];
     let currentSum = nums[0];
@@ -332,7 +542,13 @@ function maxSubArray(nums) {
     }
 
     return maxSum;
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const nums: number[] = _lines[0].split(' ').map(Number);
+const result = maxSubArray(nums);
+console.log(result);`,
     },
 
     // Binary Search - Python
@@ -345,7 +561,17 @@ function maxSubArray(nums) {
     :type target: int
     :rtype: int
     """
-    pass`,
+    pass
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    nums = list(map(int, _lines[0].split()))
+    target = int(_lines[1])
+    result = search(nums, target)
+    print(result)`,
         solution: `def search(nums, target):
     """
     :type nums: List[int]
@@ -363,7 +589,17 @@ function maxSubArray(nums) {
         else:
             right = mid - 1
 
-    return -1`,
+    return -1
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    nums = list(map(int, _lines[0].split()))
+    target = int(_lines[1])
+    result = search(nums, target)
+    print(result)`,
     },
     // Binary Search - JavaScript
     {
@@ -376,7 +612,14 @@ function maxSubArray(nums) {
  */
 function search(nums, target) {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const nums = _lines[0].split(' ').map(Number);
+const target = Number(_lines[1]);
+const result = search(nums, target);
+console.log(result);`,
         solution: `/**
  * @param {number[]} nums
  * @param {number} target
@@ -397,7 +640,14 @@ function search(nums, target) {
     }
 
     return -1;
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const nums = _lines[0].split(' ').map(Number);
+const target = Number(_lines[1]);
+const result = search(nums, target);
+console.log(result);`,
     },
     // Binary Search - TypeScript
     {
@@ -405,7 +655,14 @@ function search(nums, target) {
         language: 'typescript',
         stub: `function search(nums: number[], target: number): number {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const nums: number[] = _lines[0].split(' ').map(Number);
+const target: number = Number(_lines[1]);
+const result = search(nums, target);
+console.log(result);`,
         solution: `function search(nums: number[], target: number): number {
     let left = 0, right = nums.length - 1;
 
@@ -421,7 +678,14 @@ function search(nums, target) {
     }
 
     return -1;
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const nums: number[] = _lines[0].split(' ').map(Number);
+const target: number = Number(_lines[1]);
+const result = search(nums, target);
+console.log(result);`,
     },
 
     // Valid Parentheses - Python
@@ -433,7 +697,16 @@ function search(nums, target) {
     :type s: str
     :rtype: bool
     """
-    pass`,
+    pass
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    s = _lines[0]
+    result = is_valid(s)
+    print(str(result).lower())`,
         solution: `def is_valid(s):
     """
     :type s: str
@@ -450,7 +723,16 @@ function search(nums, target) {
         else:
             stack.append(char)
 
-    return not stack`,
+    return not stack
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    s = _lines[0]
+    result = is_valid(s)
+    print(str(result).lower())`,
     },
     // Valid Parentheses - JavaScript
     {
@@ -462,7 +744,13 @@ function search(nums, target) {
  */
 function isValid(s) {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const s = _lines[0];
+const result = isValid(s);
+console.log(JSON.stringify(result));`,
         solution: `/**
  * @param {string} s
  * @return {boolean}
@@ -483,7 +771,13 @@ function isValid(s) {
     }
 
     return stack.length === 0;
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const s = _lines[0];
+const result = isValid(s);
+console.log(JSON.stringify(result));`,
     },
     // Valid Parentheses - TypeScript
     {
@@ -491,7 +785,13 @@ function isValid(s) {
         language: 'typescript',
         stub: `function isValid(s: string): boolean {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const s: string = _lines[0];
+const result = isValid(s);
+console.log(JSON.stringify(result));`,
         solution: `function isValid(s: string): boolean {
     const stack: string[] = [];
     const mapping: Record<string, string> = { ')': '(', '}': '{', ']': '[' };
@@ -508,7 +808,13 @@ function isValid(s) {
     }
 
     return stack.length === 0;
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const s: string = _lines[0];
+const result = isValid(s);
+console.log(JSON.stringify(result));`,
     },
 
     // Merge Two Sorted Lists - Python
@@ -521,7 +827,17 @@ function isValid(s) {
     :type list2: List[int]
     :rtype: List[int]
     """
-    pass`,
+    pass
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    list1 = list(map(int, _lines[0].split())) if _lines[0].strip() else []
+    list2 = list(map(int, _lines[1].split())) if _lines[1].strip() else []
+    result = merge_two_lists(list1, list2)
+    print(' '.join(str(x) for x in result))`,
         solution: `def merge_two_lists(list1, list2):
     """
     :type list1: List[int]
@@ -542,7 +858,17 @@ function isValid(s) {
     result.extend(list1[i:])
     result.extend(list2[j:])
 
-    return result`,
+    return result
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    list1 = list(map(int, _lines[0].split())) if _lines[0].strip() else []
+    list2 = list(map(int, _lines[1].split())) if _lines[1].strip() else []
+    result = merge_two_lists(list1, list2)
+    print(' '.join(str(x) for x in result))`,
     },
     // Merge Two Sorted Lists - JavaScript
     {
@@ -555,7 +881,14 @@ function isValid(s) {
  */
 function mergeTwoLists(list1, list2) {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const list1 = _lines[0].trim() ? _lines[0].split(' ').map(Number) : [];
+const list2 = _lines[1].trim() ? _lines[1].split(' ').map(Number) : [];
+const result = mergeTwoLists(list1, list2);
+console.log(result.join(' '));`,
         solution: `/**
  * @param {number[]} list1
  * @param {number[]} list2
@@ -576,7 +909,14 @@ function mergeTwoLists(list1, list2) {
     }
 
     return result.concat(list1.slice(i)).concat(list2.slice(j));
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const list1 = _lines[0].trim() ? _lines[0].split(' ').map(Number) : [];
+const list2 = _lines[1].trim() ? _lines[1].split(' ').map(Number) : [];
+const result = mergeTwoLists(list1, list2);
+console.log(result.join(' '));`,
     },
     // Merge Two Sorted Lists - TypeScript
     {
@@ -584,7 +924,14 @@ function mergeTwoLists(list1, list2) {
         language: 'typescript',
         stub: `function mergeTwoLists(list1: number[], list2: number[]): number[] {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const list1: number[] = _lines[0].trim() ? _lines[0].split(' ').map(Number) : [];
+const list2: number[] = _lines[1].trim() ? _lines[1].split(' ').map(Number) : [];
+const result = mergeTwoLists(list1, list2);
+console.log(result.join(' '));`,
         solution: `function mergeTwoLists(list1: number[], list2: number[]): number[] {
     const result: number[] = [];
     let i = 0, j = 0;
@@ -600,7 +947,14 @@ function mergeTwoLists(list1, list2) {
     }
 
     return result.concat(list1.slice(i)).concat(list2.slice(j));
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const list1: number[] = _lines[0].trim() ? _lines[0].split(' ').map(Number) : [];
+const list2: number[] = _lines[1].trim() ? _lines[1].split(' ').map(Number) : [];
+const result = mergeTwoLists(list1, list2);
+console.log(result.join(' '));`,
     },
 
     // Longest Common Prefix - Python
@@ -612,7 +966,16 @@ function mergeTwoLists(list1, list2) {
     :type strs: List[str]
     :rtype: str
     """
-    pass`,
+    pass
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    strs = _lines[0].split()
+    result = longest_common_prefix(strs)
+    print(result)`,
         solution: `def longest_common_prefix(strs):
     """
     :type strs: List[str]
@@ -628,7 +991,16 @@ function mergeTwoLists(list1, list2) {
             if not prefix:
                 return ""
 
-    return prefix`,
+    return prefix
+
+# Do not edit below
+import sys
+
+if __name__ == "__main__":
+    _lines = sys.stdin.read().split('\\n')
+    strs = _lines[0].split()
+    result = longest_common_prefix(strs)
+    print(result)`,
     },
     // Longest Common Prefix - JavaScript
     {
@@ -640,7 +1012,13 @@ function mergeTwoLists(list1, list2) {
  */
 function longestCommonPrefix(strs) {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const strs = _lines[0].split(' ');
+const result = longestCommonPrefix(strs);
+console.log(result);`,
         solution: `/**
  * @param {string[]} strs
  * @return {string}
@@ -657,7 +1035,13 @@ function longestCommonPrefix(strs) {
     }
 
     return prefix;
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const strs = _lines[0].split(' ');
+const result = longestCommonPrefix(strs);
+console.log(result);`,
     },
     // Longest Common Prefix - TypeScript
     {
@@ -665,7 +1049,13 @@ function longestCommonPrefix(strs) {
         language: 'typescript',
         stub: `function longestCommonPrefix(strs: string[]): string {
     // Your code here
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const strs: string[] = _lines[0].split(' ');
+const result = longestCommonPrefix(strs);
+console.log(result);`,
         solution: `function longestCommonPrefix(strs: string[]): string {
     if (strs.length === 0) return "";
 
@@ -678,6 +1068,12 @@ function longestCommonPrefix(strs) {
     }
 
     return prefix;
-}`,
+}
+
+// Do not edit below
+const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');
+const strs: string[] = _lines[0].split(' ');
+const result = longestCommonPrefix(strs);
+console.log(result);`,
     },
 ];

--- a/prisma/seed-data/organizations.seed.ts
+++ b/prisma/seed-data/organizations.seed.ts
@@ -1,8 +1,8 @@
 export const organizationsData = [
     {
         id: 'org_nextlab_001',
-        name: 'Next Lab',
-        slug: 'next-lab',
+        name: 'NExT',
+        slug: 'next',
         logo: null,
     },
 ];

--- a/prisma/seed-data/task-template.seed.ts
+++ b/prisma/seed-data/task-template.seed.ts
@@ -47,15 +47,15 @@ export const taskTemplatesData = [
             paragraph('two_sum_c3', ['- -10^9 <= target <= 10^9']),
             paragraph('two_sum_c4', ['- Only one valid answer exists.']),
         ],
-        // stdin: first line is space-separated nums, second line is target
+        // stdin: line 0 = space-separated nums, line 1 = target
         // stdout: space-separated indices
         publicTestCases: [
-            { input: '2 7 11 15\n9', output: '0 1' },
-            { input: '3 2 4\n6', output: '1 2' },
+            { input: '2 7 11 15\\n9', output: '0 1' },
+            { input: '3 2 4\\n6', output: '1 2' },
         ],
         privateTestCases: [
-            { input: '3 3\n6', output: '0 1' },
-            { input: '1 5 3 7 9\n10', output: '1 3' },
+            { input: '3 3\\n6', output: '0 1' },
+            { input: '1 5 3 7 9\\n10', output: '2 3' },
         ],
         orgId: 'org_nextlab_001',
         taskType: 'Single Function',
@@ -95,7 +95,7 @@ export const taskTemplatesData = [
             paragraph('rs_c1', ['- 1 <= s.length <= 10^5']),
             paragraph('rs_c2', ['- s[i] is a printable ascii character.']),
         ],
-        // stdin: space-separated characters
+        // stdin: line 0 = space-separated characters
         // stdout: space-separated reversed characters
         publicTestCases: [{ input: 'h e l l o', output: 'o l l e h' }],
         privateTestCases: [
@@ -140,8 +140,8 @@ export const taskTemplatesData = [
             paragraph('vp_c1', ['- 1 <= s.length <= 2 * 10^5']),
             paragraph('vp_c2', ['- s consists only of printable ASCII characters.']),
         ],
-        // stdin: the string
-        // stdout: true or false
+        // stdin: line 0 = raw string
+        // stdout: true or false (lowercase)
         publicTestCases: [
             { input: 'A man, a plan, a canal: Panama', output: 'true' },
             { input: 'race a car', output: 'false' },
@@ -177,8 +177,8 @@ export const taskTemplatesData = [
                 'Write a solution (or reduce an existing one) so it has as few characters as possible.',
             ]),
         ],
-        // stdin: empty — no input needed
-        // stdout: fizzbuzz output from 1 to 100
+        // stdin: line 0 = integer n
+        // stdout: FizzBuzz string for n
         publicTestCases: [
             { input: '3', output: 'Fizz' },
             { input: '5', output: 'Buzz' },
@@ -237,7 +237,7 @@ export const taskTemplatesData = [
             paragraph('ms_c1', ['- 1 <= nums.length <= 10^5']),
             paragraph('ms_c2', ['- -10^4 <= nums[i] <= 10^4']),
         ],
-        // stdin: space-separated nums
+        // stdin: line 0 = space-separated nums
         // stdout: the maximum subarray sum
         publicTestCases: [
             { input: '-2 1 -3 4 -1 2 1 -5 4', output: '6' },
@@ -283,15 +283,15 @@ export const taskTemplatesData = [
             paragraph('bs_c2', ['- -10^4 < nums[i], target < 10^4']),
             paragraph('bs_c3', ['- nums is sorted in ascending order.']),
         ],
-        // stdin: first line is space-separated nums, second line is target
+        // stdin: line 0 = space-separated nums, line 1 = target
         // stdout: the index, or -1
         publicTestCases: [
-            { input: '-1 0 3 5 9 12\n9', output: '4' },
-            { input: '-1 0 3 5 9 12\n2', output: '-1' },
+            { input: '-1 0 3 5 9 12\\n9', output: '4' },
+            { input: '-1 0 3 5 9 12\\n2', output: '-1' },
         ],
         privateTestCases: [
-            { input: '5\n5', output: '0' },
-            { input: '2 5\n5', output: '1' },
+            { input: '5\\n5', output: '0' },
+            { input: '2 5\\n5', output: '1' },
         ],
         orgId: 'org_nextlab_001',
         taskType: 'Single Function',
@@ -326,8 +326,8 @@ export const taskTemplatesData = [
             paragraph('vp2_c1', ['- 1 <= s.length <= 10^4']),
             paragraph('vp2_c2', ["- s consists of parentheses only '()[]{}'."]),
         ],
-        // stdin: the bracket string
-        // stdout: true or false
+        // stdin: line 0 = raw bracket string
+        // stdout: true or false (lowercase)
         publicTestCases: [
             { input: '()', output: 'true' },
             { input: '()[]{}', output: 'true' },
@@ -377,16 +377,15 @@ export const taskTemplatesData = [
             paragraph('mts_c2', ['- -100 <= Node.val <= 100']),
             paragraph('mts_c3', ['- Both list1 and list2 are sorted in non-decreasing order.']),
         ],
-        // stdin: first line is space-separated list1, second line is space-separated list2
-        //        empty line represents an empty list
+        // stdin: line 0 = space-separated list1 (empty line = empty list), line 1 = space-separated list2
         // stdout: space-separated merged list, or empty string for empty result
         publicTestCases: [
-            { input: '1 2 4\n1 3 4', output: '1 1 2 3 4 4' },
-            { input: '\n', output: '' },
+            { input: '1 2 4\\n1 3 4', output: '1 1 2 3 4 4' },
+            { input: '\\n', output: '' },
         ],
         privateTestCases: [
-            { input: '\n0', output: '0' },
-            { input: '1\n2', output: '1 2' },
+            { input: '\\n0', output: '0' },
+            { input: '1\\n2', output: '1 2' },
         ],
         orgId: 'org_nextlab_001',
         taskType: 'Single Function',
@@ -421,7 +420,7 @@ export const taskTemplatesData = [
             paragraph('lcp_c2', ['- 0 <= strs[i].length <= 200']),
             paragraph('lcp_c3', ['- strs[i] consists of only lowercase English letters.']),
         ],
-        // stdin: space-separated strings
+        // stdin: line 0 = space-separated strings
         // stdout: the longest common prefix, or empty string
         publicTestCases: [
             { input: 'flower flow flight', output: 'fl' },

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -399,14 +399,12 @@ async function seedAssessments() {
             where: { applicationId: application.id },
             update: {
                 assessmentTemplateId: assessmentData.assessmentTemplateId,
-                uniqueLink: assessmentData.uniqueLink,
                 deadline: assessmentData.deadline,
             },
             create: {
                 id: assessmentData.id,
                 applicationId: application.id,
                 assessmentTemplateId: assessmentData.assessmentTemplateId,
-                uniqueLink: assessmentData.uniqueLink,
                 deadline: assessmentData.deadline,
             },
         });

--- a/src/app/(web)/(oa)/assessment/[assessmentId]/page.tsx
+++ b/src/app/(web)/(oa)/assessment/[assessmentId]/page.tsx
@@ -55,13 +55,8 @@ export default function AssessmentPage({ params }: { params: Promise<{ assessmen
         );
     }
 
-    if (assessment.phase === 'outro') {
-        return (
-            <AssessmentOutro
-                reason={assessment.outroReason}
-                candidateName={assessment.candidateName}
-            />
-        );
+    if (assessment.phase === 'outro' && assessment.assessment) {
+        return <AssessmentOutro assessment={assessment.assessment} />;
     }
 
     return (

--- a/src/app/(web)/crm/task-templates/[id]/edit/page.tsx
+++ b/src/app/(web)/crm/task-templates/[id]/edit/page.tsx
@@ -10,6 +10,8 @@ import { Button } from '@/lib/components/ui/Button';
 import TaskEditorSidebar from '@/lib/components/core/TaskEditorSidebar';
 import Breadcrumbs from '@/lib/components/core/Breadcrumbs';
 import useTestRunner from '@/lib/hooks/useTestRunner';
+import { type TestCaseDTO } from '@/lib/schemas/task-template.schema';
+import { type ProgrammingLanguage } from '@/generated/prisma';
 
 export default function TaskTemplateEditPage({ params }: { params: Promise<{ id: string }> }) {
     const { id } = use(params);
@@ -46,10 +48,14 @@ export default function TaskTemplateEditPage({ params }: { params: Promise<{ id:
         generateStubsForLanguages,
         getEditorContent,
     } = useTaskTemplateEditPage(id);
-    const { runEditPageTests } = useTestRunner(
-        getEditorContent(),
-        languages ? languages[selectedLanguage].language : 'python' // UHHHH
-    );
+    const { runEditPageTests } = useTestRunner();
+
+    const handleRunTests = (tests: TestCaseDTO[]) => {
+        const code = getEditorContent();
+        const language = languages?.[selectedLanguage]?.language;
+        if (!language) return;
+        runEditPageTests(tests, code, language as ProgrammingLanguage);
+    };
 
     if (isLoading) {
         return (
@@ -139,7 +145,7 @@ export default function TaskTemplateEditPage({ params }: { params: Promise<{ id:
                             setPublicTestCases={setPublicTestCases}
                             privateTestCases={privateTestCases}
                             setPrivateTestCases={setPrivateTestCases}
-                            runTests={runEditPageTests}
+                            runTests={handleRunTests}
                             isSaving={isSaving}
                         />
                     </div>

--- a/src/app/(web)/crm/templates/page.tsx
+++ b/src/app/(web)/crm/templates/page.tsx
@@ -41,6 +41,7 @@ import {
 } from '@/lib/components/ui/Modal';
 import { useAuth } from '@/lib/auth/auth-context';
 import { AssessmentTemplatePreview } from '@/lib/components/templates/AssessmentTemplatePreview';
+import { toast } from 'sonner';
 
 export default function TemplatesPage() {
     const [selectedTaskTemplate, setSelectedTaskTemplate] =
@@ -132,7 +133,7 @@ export default function TemplatesPage() {
             });
             router.push(`/crm/task-templates/${created.id}/edit`);
         } catch (err) {
-            console.error('Failed to create task template:', err);
+            toast.error(`Failed to create task template: ${err}`);
         } finally {
             setIsCreating(false);
         }

--- a/src/app/api/runner/[taskTemplateId]/route.ts
+++ b/src/app/api/runner/[taskTemplateId]/route.ts
@@ -1,12 +1,12 @@
+import { type NextRequest } from 'next/server';
 import judge0Connector, {
+    formatJudgeResult,
     type JudgeSubmissionRequestBody,
 } from '@/lib/connectors/judge0.connector';
 import { SubmissionSchema } from '@/lib/schemas/submission.schema';
 import TaskTemplateService from '@/lib/services/task-template.service';
-// import { getSession } from '@/lib/utils/auth.utils';
 import { handleError } from '@/lib/utils/errors.utils';
 import { mapLanguageToJudge } from '@/lib/utils/language.utils';
-import { type NextRequest } from 'next/server';
 
 export async function POST(
     request: NextRequest,
@@ -19,20 +19,26 @@ export async function POST(
         const languageId = mapLanguageToJudge(parsed.language);
         const taskTemplate = await TaskTemplateService.getTaskTemplate(
             taskTemplateId,
-            'TODO: REPLACE THIS LATER LAITH WITH COOKIE'
+            'org_nextlab_001' // lmk if we want this to stay as the TODO
         );
-        const tests = [...taskTemplate.privateTestCases, ...taskTemplate.publicTestCases];
+        const tests = [...taskTemplate.publicTestCases, ...taskTemplate.privateTestCases];
         const formatted: JudgeSubmissionRequestBody[] = tests.map((test) => ({
             source_code: parsed.code,
             language_id: languageId,
-            stdin: test.input,
-            expected_output: test.output,
+            // NOTE(laith): we're replacing newline characters to actual newline characters to
+            // display on the client that newline characters indicate the next parameter
+            stdin: test.input.replace(/\\n/g, '\n'),
+            // NOTE(laith): print() and console.log() auto append a newline character, so it would
+            // double append, this removes it and the judge0Connector will normalize it for us
+            expected_output: test.output.endsWith('\n') ? test.output : `${test.output}\n`,
         }));
 
         const result = await judge0Connector.executeSubmissions(formatted);
+        const formattedResults = result.map(formatJudgeResult);
+
         return Response.json({
-            data: result,
-            status: 200,
+            data: formattedResults,
+            status: 201,
         });
     } catch (err) {
         return handleError(err);

--- a/src/app/api/runner/route.ts
+++ b/src/app/api/runner/route.ts
@@ -2,6 +2,7 @@ import { handleError } from '@/lib/utils/errors.utils';
 import { assertRecruiterOrAbove } from '@/lib/utils/permissions.utils';
 import { type NextRequest } from 'next/server';
 import judge0Connector, {
+    formatJudgeResult,
     type JudgeSubmissionRequestBody,
 } from '@/lib/connectors/judge0.connector';
 import { TestSubmissionSchema } from '@/lib/schemas/submission.schema';
@@ -16,15 +17,20 @@ export async function POST(request: NextRequest) {
         const formatted: JudgeSubmissionRequestBody[] = parsed.tests.map((test) => ({
             source_code: parsed.code,
             language_id: languageId,
-            stdin: test.input,
-            expected_output: test.output,
+            // NOTE(laith): we're replacing newline characters to actual newline characters to
+            // display on the client that newline characters indicate the next parameter
+            stdin: test.input.replace(/\\n/g, '\n'),
+            // NOTE(laith): print() and console.log() auto append a newline character, so it would
+            // double append, this removes it and the judge0Connector will normalize it for us
+            expected_output: test.output.endsWith('\n') ? test.output : `${test.output}\n`,
         }));
 
         const result = await judge0Connector.executeSubmissions(formatted);
+        const formattedResults = result.map(formatJudgeResult);
 
         return Response.json({
-            data: result,
-            status: 200,
+            data: formattedResults,
+            status: 201,
         });
     } catch (err) {
         return handleError(err);

--- a/src/lib/api/runner.ts
+++ b/src/lib/api/runner.ts
@@ -2,11 +2,11 @@ import {
     type SubmissionSchemaDTO,
     type TestSubmissionSchemaDTO,
 } from '@/lib/schemas/submission.schema';
-import { type JudgeResultRequestBody } from '@/lib/connectors/judge0.connector';
+import type { CandidateTestResult } from '@/lib/types/candidate-assessment.types';
 
 export async function runEditorSubmission(
     submission: TestSubmissionSchemaDTO
-): Promise<JudgeResultRequestBody> {
+): Promise<CandidateTestResult[]> {
     const result = await fetch(`/api/runner`, {
         method: 'POST',
         headers: {
@@ -27,7 +27,7 @@ export async function runEditorSubmission(
 export async function runAssessmentSubmission(
     taskTemplateId: string,
     submission: SubmissionSchemaDTO
-): Promise<JudgeResultRequestBody> {
+): Promise<CandidateTestResult[]> {
     const result = await fetch(`/api/runner/${taskTemplateId}`, {
         method: 'POST',
         headers: {

--- a/src/lib/components/assessment-flow/AssessmentIntro.tsx
+++ b/src/lib/components/assessment-flow/AssessmentIntro.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import type { CandidateAssessment } from '@/lib/types/candidate-assessment.types';
 import { formatDeadline, formatDuration } from '@/lib/utils/date.utils';
+import { Button } from '@/lib/components/ui/Button';
 
 type AssessmentIntroProps = {
     assessment: CandidateAssessment;
@@ -7,69 +9,71 @@ type AssessmentIntroProps = {
     onStart: () => void;
 };
 
-const GUIDELINES = [
-    'Questions are linear - you cannot go back to previous questions.',
-    'Changing or leaving this tab will be reported.',
-    'Refreshing the page will end your assessment.',
-    'Your work is automatically submitted when time runs out.',
-];
-
 export default function AssessmentIntro({
     assessment,
     totalTimeSeconds,
     onStart,
 }: AssessmentIntroProps) {
-    const questionCount = assessment.assessmentTemplate.tasks.length;
+    const [guidelinesChecked, setGuidelinesChecked] = useState(false);
 
     return (
         <div className="bg-sarge-gray-50 flex h-full items-center justify-center p-8">
-            <div className="border-sarge-gray-200 bg-background flex w-full max-w-xl flex-col gap-6 rounded-2xl border p-10 shadow-sm">
+            <div className="border-sarge-gray-200 bg-background flex w-full max-w-2xl flex-col gap-6 rounded-2xl border p-10 shadow-sm">
                 <div>
-                    <h1 className="text-sarge-gray-800 text-2xl font-semibold">
+                    <h1 className="text-sarge-gray-800 py-3 text-xl font-bold">
                         {assessment.assessmentTemplate.title}
                     </h1>
-                    <div className="text-sarge-gray-500 mt-3 flex gap-6 text-sm">
-                        <span>
-                            <span className="text-sarge-gray-700 font-medium">{questionCount}</span>{' '}
-                            question{questionCount !== 1 ? 's' : ''}
-                        </span>
-                        <span>
-                            <span className="text-sarge-gray-700 font-medium">
-                                {formatDuration(totalTimeSeconds)}
-                            </span>{' '}
-                            total time
-                        </span>
-                        <span>
-                            Due{' '}
-                            <span className="text-sarge-gray-700 font-medium">
-                                {formatDeadline(assessment.deadline)}
-                            </span>
-                        </span>
+                    <div>
+                        <p className="text-md mt-2">Hey {assessment.candidateName},</p>
+                        <p className="text-md mt-2">
+                            Thank you for applying to {assessment.organizationName}! Please complete
+                            the coding assessment below to continue your application.
+                        </p>
                     </div>
                 </div>
 
                 <div>
-                    <p className="text-sarge-gray-700 mb-3 text-sm font-medium">Before you start</p>
-                    <ul className="flex flex-col gap-2">
-                        {GUIDELINES.map((g) => (
-                            <li
-                                key={g}
-                                className="text-sarge-gray-600 flex items-start gap-2 text-sm"
-                            >
-                                <span className="bg-sarge-gray-300 mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full" />
-                                {g}
-                            </li>
-                        ))}
+                    <p className="text-md mb-1 font-bold">Assessment Details</p>
+                    <ul className="text-md flex list-disc flex-col pl-5">
+                        <li>Test type: Coding assessment</li>
+                        <li>Duration: {formatDuration(totalTimeSeconds)}</li>
+                        <li>Expires: {formatDeadline(assessment.deadline)}</li>
                     </ul>
                 </div>
 
-                <button
-                    type="button"
-                    onClick={onStart}
-                    className="bg-sarge-primary-500 hover:bg-sarge-primary-600 text-primary-foreground h-11 w-full rounded-lg text-sm font-medium transition-colors"
-                >
-                    Start Assessment
-                </button>
+                <div>
+                    <p className="text-md mb-1 font-bold">Before you begin:</p>
+                    <ul className="text-md flex list-disc flex-col pl-5">
+                        <li>You cannot go back and forth between questions</li>
+                        <li>Do not refresh or close the page — your progress will auto-submit</li>
+                        <li>Tab/window switching is monitored and reported</li>
+                    </ul>
+                </div>
+
+                <div className="mt-12 flex flex-col items-center gap-5">
+                    <label className="text-md mt-4 flex items-center gap-2">
+                        <input
+                            type="checkbox"
+                            checked={guidelinesChecked}
+                            onChange={(e) => setGuidelinesChecked(e.target.checked)}
+                            className="mt-0.5"
+                        />
+                        <span>
+                            I agree to complete this assessment independently, without the use of AI
+                            tools, external resources, or assistance from others. I understand that
+                            violations are monitored and reported.
+                        </span>
+                    </label>
+                    <Button
+                        className="px-4 py-2"
+                        onClick={onStart}
+                        variant="primary"
+                        disabled={!guidelinesChecked}
+                    >
+                        Begin Assessment
+                    </Button>
+                    <p className="text-sm">You can also use this link to open your assessment.</p>
+                </div>
             </div>
         </div>
     );

--- a/src/lib/components/assessment-flow/AssessmentOutro.tsx
+++ b/src/lib/components/assessment-flow/AssessmentOutro.tsx
@@ -8,29 +8,38 @@ type AssessmentOutroProps = {
 export default function AssessmentOutro({ assessment }: AssessmentOutroProps) {
     const handleCloseTab = () => {
         window.close();
+        // browser likely blocks it -> see javascript
+        // apparently hackerrank has a "you can safely close this tab" message so i put that too
+        alert('Your browser likely blocked the tab from closing. Please close this tab manually.');
     };
 
     return (
         <div className="bg-sarge-gray-50 flex h-full items-center justify-center p-8">
-            <div className="border-sarge-gray-200 bg-background flex w-full max-w-xl flex-col gap-6 rounded-2xl border p-10 shadow-sm">
+            <div className="border-sarge-gray-200 bg-background flex w-full max-w-2xl flex-col gap-6 rounded-2xl border p-10 shadow-sm">
                 <div>
                     <h1 className="text-sarge-gray-800 py-3 text-xl font-bold">
                         {assessment.assessmentTemplate.title}
                     </h1>
                     <div>
-                        <p className="mt-2 text-sm">
+                        <p className="mt-2 text-md">
                             Your submission has been received. The {assessment.organizationName}{' '}
                             team will be in touch with next steps within the next few weeks.
                         </p>
+                        <p className="mt-2 text-md">You can safely close this tab.</p>
                     </div>
                 </div>
-
-                <Button onClick={handleCloseTab} variant="primary">
+                
+                <div className="flex flex-col items-center">
+                <Button className="w-10 px-12 py-2" onClick={handleCloseTab} variant="primary">
                     Close Tab
                 </Button>
-                <p className="text-xs">
-                    For any questions, please reach out to the exam administrator at .
+                </div>
+                <p className="text-sm">
+                    For any questions, please reach out to the exam administrator at [email].
                 </p>
+                <div className="m-50">
+
+                </div>
             </div>
         </div>
     );

--- a/src/lib/components/assessment-flow/AssessmentOutro.tsx
+++ b/src/lib/components/assessment-flow/AssessmentOutro.tsx
@@ -1,43 +1,36 @@
-import Image from 'next/image';
-import Link from 'next/link';
-import type { OutroReason } from '@/lib/types/candidate-assessment.types';
+import { Button } from '@/lib/components/ui/Button';
+import type { CandidateAssessment } from '@/lib/types/candidate-assessment.types';
 
 type AssessmentOutroProps = {
-    reason: OutroReason;
-    candidateName: string;
+    assessment: CandidateAssessment;
 };
 
-export default function AssessmentOutro({ reason, candidateName }: AssessmentOutroProps) {
-    const isExpired = reason === 'expired';
+export default function AssessmentOutro({ assessment }: AssessmentOutroProps) {
+    const handleCloseTab = () => {
+        window.close();
+    };
 
     return (
         <div className="bg-sarge-gray-50 flex h-full items-center justify-center p-8">
-            <div className="border-sarge-gray-200 bg-background flex w-full max-w-md flex-col items-center gap-6 rounded-2xl border p-10 text-center shadow-sm">
-                <Image
-                    src="/GreyWinstonLogoMark.svg"
-                    width={80}
-                    height={80}
-                    alt="Winston"
-                    className="opacity-60"
-                />
-
+            <div className="border-sarge-gray-200 bg-background flex w-full max-w-xl flex-col gap-6 rounded-2xl border p-10 shadow-sm">
                 <div>
-                    <h1 className="text-sarge-gray-800 text-2xl font-semibold">
-                        {isExpired ? 'Your time is up' : 'Assessment submitted!'}
+                    <h1 className="text-sarge-gray-800 py-3 text-xl font-bold">
+                        {assessment.assessmentTemplate.title}
                     </h1>
-                    <p className="text-sarge-gray-500 mt-2 text-sm">
-                        {isExpired
-                            ? "Don't worry, we submitted your work."
-                            : `Thank you for completing your assessment${candidateName ? `, ${candidateName}` : ''}.`}
-                    </p>
+                    <div>
+                        <p className="mt-2 text-sm">
+                            Your submission has been received. The {assessment.organizationName}{' '}
+                            team will be in touch with next steps within the next few weeks.
+                        </p>
+                    </div>
                 </div>
 
-                <Link
-                    href="/"
-                    className="bg-sarge-primary-500 hover:bg-sarge-primary-600 text-primary-foreground flex h-11 items-center justify-center rounded-lg px-8 text-sm font-medium transition-colors"
-                >
-                    Continue
-                </Link>
+                <Button onClick={handleCloseTab} variant="primary">
+                    Close Tab
+                </Button>
+                <p className="text-xs">
+                    For any questions, please reach out to the exam administrator at .
+                </p>
             </div>
         </div>
     );

--- a/src/lib/components/assessment-flow/AssessmentOutro.tsx
+++ b/src/lib/components/assessment-flow/AssessmentOutro.tsx
@@ -21,25 +21,23 @@ export default function AssessmentOutro({ assessment }: AssessmentOutroProps) {
                         {assessment.assessmentTemplate.title}
                     </h1>
                     <div>
-                        <p className="mt-2 text-md">
+                        <p className="text-md mt-2">
                             Your submission has been received. The {assessment.organizationName}{' '}
                             team will be in touch with next steps within the next few weeks.
                         </p>
-                        <p className="mt-2 text-md">You can safely close this tab.</p>
+                        <p className="text-md mt-2">You can safely close this tab.</p>
                     </div>
                 </div>
-                
+
                 <div className="flex flex-col items-center">
-                <Button className="w-10 px-12 py-2" onClick={handleCloseTab} variant="primary">
-                    Close Tab
-                </Button>
+                    <Button className="w-10 px-12 py-2" onClick={handleCloseTab} variant="primary">
+                        Close Tab
+                    </Button>
                 </div>
                 <p className="text-sm">
                     For any questions, please reach out to the exam administrator at [email].
                 </p>
-                <div className="m-50">
-
-                </div>
+                <div className="m-50"></div>
             </div>
         </div>
     );

--- a/src/lib/components/assessment-flow/AssessmentTestCasesPanel.tsx
+++ b/src/lib/components/assessment-flow/AssessmentTestCasesPanel.tsx
@@ -28,7 +28,7 @@ export default function AssessmentTestCasesPanel({
 }: AssessmentTestCasesPanelProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [panelHeight, setPanelHeight] = useState(PANEL_DEFAULT_HEIGHT);
-    const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+    const [selectedIndices, setSelectedIndices] = useState<Set<number>>(new Set());
     const dragRef = useRef<{ startY: number; startHeight: number } | null>(null);
 
     const passCount = results.filter((r) => r.status === 'passed').length;
@@ -40,7 +40,15 @@ export default function AssessmentTestCasesPanel({
     );
 
     function toggleSelected(i: number) {
-        setSelectedIndex((prev) => (prev === i ? null : i));
+        setSelectedIndices((prev) => {
+            const next = new Set(prev);
+            if (next.has(i)) {
+                next.delete(i);
+            } else {
+                next.add(i);
+            }
+            return next;
+        });
     }
 
     // this is the dragging handle for when the panel is open and we want to resize it
@@ -116,7 +124,10 @@ export default function AssessmentTestCasesPanel({
                 <div className="flex items-center gap-2">
                     <Button
                         variant="secondary"
-                        onClick={onRunTests}
+                        onClick={() => {
+                            setIsOpen(true);
+                            onRunTests();
+                        }}
                         className="flex h-9 items-center gap-2 rounded-lg border px-4 text-sm font-medium"
                     >
                         <Play className="size-4" />
@@ -142,7 +153,7 @@ export default function AssessmentTestCasesPanel({
                             index={i}
                             test={tc}
                             result={results[i] ?? { status: 'default' }}
-                            selected={selectedIndex === i}
+                            selected={selectedIndices.has(i)}
                             onSelect={() => toggleSelected(i)}
                         />
                     ))}

--- a/src/lib/components/core/Sidebar.tsx
+++ b/src/lib/components/core/Sidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Home, File, Users, Book, Archive, Settings, ChevronDown } from 'lucide-react';
+import { Home, File, Users, Settings, ChevronDown } from 'lucide-react';
 import { useAuth } from '@/lib/auth/auth-context';
 import Image from 'next/image';
 import useOnboardingState from '@/lib/hooks/useOnboardingState';
@@ -693,16 +693,6 @@ const sidebarMenuItems = [
         title: 'Positions',
         url: '/crm/positions',
         icon: Users,
-    },
-    {
-        title: 'Live Assessments',
-        url: '#',
-        icon: Book,
-    },
-    {
-        title: 'Archived Assessments',
-        url: '#',
-        icon: Archive,
     },
 ];
 

--- a/src/lib/components/core/TaskDetailsTab.tsx
+++ b/src/lib/components/core/TaskDetailsTab.tsx
@@ -7,6 +7,7 @@ import { Combobox } from '@/lib/components/ui/Combobox';
 import { createTag } from '@/lib/api/tags';
 import type { BlockNoteContent } from '@/lib/types/task-template.types';
 import type { TagDTO } from '@/lib/schemas/tag.schema';
+import { toast } from 'sonner';
 
 // BlockNote: https://www.blocknotejs.org/docs/nextjs
 const BlockNoteEditor = dynamic(() => import('@/lib/components/core/BlockNoteEditor'), {
@@ -58,7 +59,7 @@ export default function TaskDetailsTab({
             setAvailableTags((prev) => [...prev, newTag]);
             setTags((prev: TagDTO[]) => [...prev, newTag]);
         } catch (err) {
-            console.error('Failed to create tag:', err);
+            toast.error(`Failed to create tag: ${err}`);
         }
     };
 

--- a/src/lib/components/modal/InviteUsersModal.tsx
+++ b/src/lib/components/modal/InviteUsersModal.tsx
@@ -98,8 +98,7 @@ export default function InviteUsersModal({
                 toast.error('An error occurred... please try again');
             }
         } catch (err) {
-            console.error('Error inviting users:', err);
-            toast.error('An error occurred... please try again');
+            toast.error(`Error inviting users: ${err}`);
         } finally {
             setInviting(false);
         }

--- a/src/lib/components/modal/LostConnectionModal.tsx
+++ b/src/lib/components/modal/LostConnectionModal.tsx
@@ -9,7 +9,11 @@ export type LostConnectionModalProps = {
 export function LostConnectionModal({ open, onOpenChange }: LostConnectionModalProps) {
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="h-[180px] w-[340px] gap-4" showCloseButton={false}>
+            <DialogContent
+                className="h-[184px] w-[361px] gap-4"
+                backgroundClassName="backdrop-blur-md"
+                showCloseButton={false}
+            >
                 <VisuallyHidden>
                     <DialogTitle>Network Disconnected</DialogTitle>
                 </VisuallyHidden>

--- a/src/lib/components/modal/WindowUnfocusedModal.tsx
+++ b/src/lib/components/modal/WindowUnfocusedModal.tsx
@@ -1,4 +1,6 @@
 import { Button } from '@/lib/components/ui/Button';
+import { Dialog, DialogContent, DialogTitle } from '@/lib/components/ui/Modal';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 
 type WindowUnfocusedModalProps = {
     open: boolean;
@@ -6,21 +8,28 @@ type WindowUnfocusedModalProps = {
 };
 
 export function WindowUnfocusedModal({ open, onAcknowledge }: WindowUnfocusedModalProps) {
-    if (!open) return null;
-
     return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/25 p-4 backdrop-blur-md">
-            <div className="bg-sarge-gray-0 border-sarge-gray-200 flex w-full max-w-[380px] flex-col items-center gap-4 rounded-lg border px-8 py-7 text-center shadow-lg">
-                <div className="space-y-3">
-                    <h2 className="text-sarge-gray-900 text-base leading-snug font-bold">
-                        You can&apos;t unfocus your assessment window during the exam
-                    </h2>
-                    <p className="text-sarge-gray-600 text-sm">The admin has been notified.</p>
+        <Dialog open={open} onOpenChange={() => {}}>
+            <DialogContent
+                className="h-[184px] w-[361px] gap-4"
+                backgroundClassName="bg-white/25 backdrop-blur-md"
+                showCloseButton={false}
+            >
+                <VisuallyHidden>
+                    <DialogTitle>Window Unfocused</DialogTitle>
+                </VisuallyHidden>
+                <div className="flex h-full flex-col items-center justify-center gap-4 px-6 text-center">
+                    <div className="space-y-1">
+                        <p className="text-md font-semibold tracking-wide">
+                            You can&apos;t unfocus your window during the exam
+                        </p>
+                        <p className="text-sm">The admin has been notified.</p>
+                    </div>
+                    <Button className="h-9 min-w-28 px-5" onClick={onAcknowledge}>
+                        I understand
+                    </Button>
                 </div>
-                <Button className="h-9 min-w-28 px-5" onClick={onAcknowledge}>
-                    I understand
-                </Button>
-            </div>
-        </div>
+            </DialogContent>
+        </Dialog>
     );
 }

--- a/src/lib/components/templates/AssessmentTaskTemplatePreview.tsx
+++ b/src/lib/components/templates/AssessmentTaskTemplatePreview.tsx
@@ -12,7 +12,7 @@ export interface AssessmentTaskTemplatePreviewProps {
 export function AssessmentTaskTemplatePreview({
     taskTemplatePreview,
 }: AssessmentTaskTemplatePreviewProps) {
-    const { title } = taskTemplatePreview;
+    const { title, estimatedTime } = taskTemplatePreview;
     return (
         <div className="flex h-full w-full flex-col gap-2 px-6 py-4">
             <div className="inline-flex flex-col items-start gap-1 self-stretch pl-3">
@@ -21,8 +21,9 @@ export function AssessmentTaskTemplatePreview({
                 </h2>
                 <div className="inline-flex items-center justify-start gap-2 self-stretch">
                     <AlarmClock className="h-5 w-5 text-neutral-700" />
-                    {/* TODO: add task template time limit field here */}
-                    <p className="text-body-s font-medium text-neutral-800"> Coming Soon... </p>
+                    <p className="text-body-s font-medium text-neutral-800">
+                        {estimatedTime} minutes
+                    </p>
                 </div>
             </div>
             <div>

--- a/src/lib/components/templates/AssessmentTemplateItem.tsx
+++ b/src/lib/components/templates/AssessmentTemplateItem.tsx
@@ -51,7 +51,7 @@ export default function AssessmentTemplateItem({
                 </div>
 
                 {estimatedTime > 0 && (
-                    <span className="text-label-xs ml-2 shrink-0">{estimatedTime}min</span>
+                    <span className="text-label-xs ml-2 shrink-0">{estimatedTime} minutes</span>
                 )}
             </div>
         </div>

--- a/src/lib/components/templates/AssessmentTemplatePreview.tsx
+++ b/src/lib/components/templates/AssessmentTemplatePreview.tsx
@@ -93,15 +93,22 @@ export function AssessmentTemplatePreview({
                     <h1 className="text-display-xs text-foreground truncate font-medium">
                         {assessmentTemplatePreview.title}
                     </h1>
-                    <div className="flex flex-row items-center gap-0.5">
-                        <p className="text-body-s font-medium text-gray-400">Assigned to</p>
-                        <p className="text-label-s text-sarge-primary-600 underline">
-                            {assessmentTemplatePreview.positions.length > 0
-                                ? assessmentTemplatePreview.positions
-                                      .map((position) => position.title)
-                                      .join(', ')
-                                : '0 positions'}
-                        </p>
+                    <div className="flex flex-row flex-wrap items-center gap-0.5">
+                        <p className="text-body-s font-medium text-gray-400">Assigned to </p>
+                        {assessmentTemplatePreview.positions.length > 0 ? (
+                            assessmentTemplatePreview.positions.map((position, index) => (
+                                <span key={position.id}>
+                                    <span className="text-label-s text-sarge-primary-600 underline">
+                                        {position.title}
+                                    </span>
+                                    {index < assessmentTemplatePreview.positions.length - 1 && ','}
+                                </span>
+                            ))
+                        ) : (
+                            <p className="text-label-s text-sarge-primary-600 underline">
+                                0 positions
+                            </p>
+                        )}
                     </div>
                 </div>
                 <Button variant="secondary" className="h-fit px-4 py-2" asChild>

--- a/src/lib/components/ui/Modal.tsx
+++ b/src/lib/components/ui/Modal.tsx
@@ -40,15 +40,17 @@ function DialogOverlay({
 
 function DialogContent({
     className,
+    backgroundClassName,
     children,
     showCloseButton = true,
     ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
     showCloseButton?: boolean;
+    backgroundClassName?: string;
 }) {
     return (
         <DialogPortal data-slot="dialog-portal">
-            <DialogOverlay />
+            <DialogOverlay className={backgroundClassName} />
             <DialogPrimitive.Content
                 data-slot="dialog-content"
                 className={cn(

--- a/src/lib/connectors/judge0.connector.ts
+++ b/src/lib/connectors/judge0.connector.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, InternalServerException } from '@/lib/utils/errors.utils';
 import { sleep } from '@/lib/utils/utils';
+import type { CandidateTestResult } from '@/lib/types/candidate-assessment.types';
 
 export interface JudgeSubmissionRequestBody {
     source_code: string;
@@ -17,6 +18,15 @@ export interface JudgeResultRequestBody {
         description: string;
     };
     token: string;
+}
+
+export function formatJudgeResult(result: JudgeResultRequestBody): CandidateTestResult {
+    return {
+        stdout: result.stdout,
+        stderr: result.stderr,
+        description: result.status?.description,
+        statusId: result.status?.id,
+    };
 }
 
 class Judge0Connector {
@@ -193,6 +203,13 @@ class Judge0Connector {
     ): Promise<JudgeResultRequestBody[]> {
         const tokens = await this.registerSubmissions(submissions);
         const { allResults } = await this.waitForSubmissions(tokens, totalTimeout);
+        const tokenIndexMap = new Map(tokens.map((token, index) => [token, index]));
+
+        // Sort results by their original submission order (this assumes judge0 returns the tokens in the right order)\
+        // in my practice this is true but I am unsure
+        allResults.sort(
+            (a, b) => (tokenIndexMap.get(a.token) ?? 0) - (tokenIndexMap.get(b.token) ?? 0)
+        );
         return allResults;
     }
 }

--- a/src/lib/hooks/useAssessment.ts
+++ b/src/lib/hooks/useAssessment.ts
@@ -122,7 +122,7 @@ export default function useAssessment(assessmentId: string) {
 
     // the timer is in seconds however our model is in minutes
     const totalEstimatedMinutes = sections.reduce(
-        (sum, s) => sum + (s.taskTemplate.estimatedTime ?? 0),
+        (sum, s) => sum + s.taskTemplate.estimatedTime,
         0
     );
     const totalTimeSeconds = totalEstimatedMinutes * 60;

--- a/src/lib/hooks/useAssessment.ts
+++ b/src/lib/hooks/useAssessment.ts
@@ -6,14 +6,17 @@ import { type Monaco } from '@monaco-editor/react';
 import { toast } from 'sonner';
 import { getCandidateAssessment, submitCandidateAssessment } from '@/lib/api/candidate-assessment';
 import { useAssessmentTimer } from '@/lib/hooks/useAssessmentTimer';
+import useTestRunner from '@/lib/hooks/useTestRunner';
 import type {
     AssessmentPhase,
     AssessmentQuestion,
     CandidateAssessment,
     OutroReason,
     SectionState,
+    TestCaseResultStatus,
 } from '@/lib/types/candidate-assessment.types';
 import { createToken } from '@/lib/api/token';
+import { type ProgrammingLanguage } from '@/generated/prisma';
 
 function buildInitialSections(questions: AssessmentQuestion[]): SectionState[] {
     return questions.map((q, i) => {
@@ -51,6 +54,71 @@ export default function useAssessment(assessmentId: string) {
     useEffect(() => {
         currentSectionIndexRef.current = currentSectionIndex;
     }, [currentSectionIndex]);
+
+    const {
+        error: testError,
+        loading: testLoading,
+        output: testOutput,
+        runAssessmentTests,
+        reset: resetTests,
+    } = useTestRunner();
+
+    useEffect(() => {
+        if (testLoading) {
+            setSections((prev) =>
+                prev.map((section) => ({
+                    ...section,
+                    testCaseResults: section.testCaseResults.map((test) => ({
+                        ...test,
+                        status: 'loading',
+                    })),
+                }))
+            );
+        } else if (testError) {
+            setSections((prev) =>
+                prev.map((section) => ({
+                    ...section,
+                    testCaseResults: section.testCaseResults.map((test) => ({
+                        ...test,
+                        status: 'runtime_error',
+                        actualOutput: 'An error occurred while running tests.',
+                    })),
+                }))
+            );
+        } else if (testOutput) {
+            setSections((prev) =>
+                prev.map((section) => {
+                    return {
+                        ...section,
+                        testCaseResults: section.testCaseResults.map((test, i) => ({
+                            ...test,
+                            status: resolveStatusId(testOutput[i]?.statusId ?? 0),
+                            actualOutput: testOutput[i]?.stdout ?? testOutput[i]?.stderr ?? '',
+                        })),
+                    };
+                })
+            );
+        }
+    }, [testLoading, testError, testOutput, currentSectionIndex]);
+
+    function resolveStatusId(statusId: number): TestCaseResultStatus {
+        switch (statusId) {
+            case 3:
+                return 'passed';
+            case 5:
+            case 7:
+            case 8:
+            case 9:
+            case 10:
+            case 11:
+            case 12:
+                return 'runtime_error';
+            case 4:
+                return 'failed';
+            default:
+                return 'failed';
+        }
+    }
 
     // the timer is in seconds however our model is in minutes
     const totalEstimatedMinutes = sections.reduce(
@@ -122,6 +190,7 @@ export default function useAssessment(assessmentId: string) {
             handleSubmitAssessment('submitted');
         } else {
             setIsTransitioning(true);
+            resetTests();
             setTimeout(() => {
                 setSections((prev) =>
                     prev.map((s, i) => {
@@ -132,15 +201,34 @@ export default function useAssessment(assessmentId: string) {
                     })
                 );
                 setCurrentSectionIndex((prev) => prev + 1);
+                setSections((prev) =>
+                    prev.map((s) => {
+                        return {
+                            ...s,
+                            testCaseResults: s.testCaseResults.map(() => {
+                                return { status: 'default' };
+                            }),
+                        };
+                    })
+                );
                 setIsTransitioning(false);
             }, 200);
         }
     }
 
-    function updateCode(code: string) {
-        setSections((prev) =>
-            prev.map((s, i) => (i === currentSectionIndexRef.current ? { ...s, code } : s))
-        );
+    function updateCode() {
+        const code = editorRef.current?.getValue() ?? '';
+        setSections((prev) => prev.map((s, i) => (i === currentSectionIndex ? { ...s, code } : s)));
+
+        return code;
+    }
+
+    function runTests() {
+        const code = updateCode() || '';
+        const section = sections[currentSectionIndex];
+        if (!section) return;
+
+        runAssessmentTests(section.taskTemplateId, code, section.language as ProgrammingLanguage);
     }
 
     function changeLanguage(language: string) {
@@ -162,58 +250,12 @@ export default function useAssessment(assessmentId: string) {
         }
     }
 
-    // TODO: Replace with Judge0 execution
-    function runTests() {
-        const section = sections[currentSectionIndex];
-        if (!section) return;
-        if (section.testCaseResults.some((r) => r.status === 'loading')) return;
-
-        const MOCK_STATUSES = ['passed', 'failed', 'runtime_error'] as const;
-
-        setSections((prev) =>
-            prev.map((s, i) =>
-                i === currentSectionIndex
-                    ? {
-                          ...s,
-                          testCaseResults: s.testCaseResults.map(() => ({
-                              status: 'loading' as const,
-                          })),
-                      }
-                    : s
-            )
-        );
-
-        setTimeout(() => {
-            setSections((prev) =>
-                prev.map((s, i) => {
-                    if (i !== currentSectionIndex) return s;
-                    return {
-                        ...s,
-                        testCaseResults: s.testCaseResults.map((_, idx) => {
-                            const status =
-                                MOCK_STATUSES[Math.floor(Math.random() * MOCK_STATUSES.length)];
-                            const tc = section.taskTemplate.publicTestCases[idx];
-                            if (status === 'passed')
-                                return { status, actualOutput: tc?.output ?? '' };
-                            if (status === 'runtime_error')
-                                return {
-                                    status,
-                                    actualOutput: 'Timeout Error: Execution Time Exceeded',
-                                };
-                            return { status, actualOutput: 'wrong_answer' };
-                        }),
-                    };
-                })
-            );
-        }, 1500);
-    }
-
     function handleEditorMount(editorInstance: editor.IStandaloneCodeEditor, monaco: Monaco) {
         editorRef.current = editorInstance;
         monacoRef.current = monaco;
 
         editorInstance.onDidChangeModelContent(() => {
-            updateCode(editorInstance.getValue());
+            updateCode();
         });
     }
 
@@ -234,6 +276,7 @@ export default function useAssessment(assessmentId: string) {
         isSubmitting,
         isTransitioning,
         error,
+        testError,
         startAssessment,
         submitAndContinue,
         updateCode,

--- a/src/lib/hooks/useHeartbeat.ts
+++ b/src/lib/hooks/useHeartbeat.ts
@@ -1,7 +1,7 @@
 import useWebSocket from 'react-use-websocket';
 import { ReadyState } from 'react-use-websocket';
 
-const WS_URL = 'ws://localhost:8080';
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? 'ws://localhost:8080';
 
 export function useHeartbeat(token: string | null) {
     const ws = useWebSocket(token ? `${WS_URL}?token=${token}` : null, {

--- a/src/lib/hooks/useTaskTemplateEditPage.ts
+++ b/src/lib/hooks/useTaskTemplateEditPage.ts
@@ -277,11 +277,38 @@ export default function useTaskTemplateEditPage(taskTemplateId: string) {
                     if (lang) {
                         editorModels.current[lang.language]?.setValue(stub);
 
-                        if (editorModels.current[`${lang.language}-solution`].getValue() === '') {
+                        // NOTE(laith): update Monaco models directly after generation so the editor
+                        // reflects new stubs immediately without requiring a tab switch to trigger a re-render
+                        if (
+                            (editorModels.current[`${lang.language}-solution`]?.getValue() ??
+                                '') === ''
+                        ) {
                             editorModels.current[`${lang.language}-solution`]?.setValue(stub);
                         }
                     }
                 });
+
+                // NOTE(laith): handles the case where the model doesn't exist yet (e.g. the user
+                // never visited that tab), since the setValue calls above don't do anything on "undefined" models
+                const activeLang = currentLanguages[selectedLanguage];
+                if (activeLang && editorRef.current && monacoRef.current) {
+                    const newStub = generatedById.get(activeLang.id);
+                    if (newStub !== undefined) {
+                        const key =
+                            activeFileTab === 'task'
+                                ? activeLang.language
+                                : `${activeLang.language}-solution`;
+                        if (!editorModels.current[key]) {
+                            const newModel = monacoRef.current.editor.createModel(
+                                newStub,
+                                activeLang.language
+                            );
+                            editorModels.current[key] = newModel;
+                            editorRef.current.setModel(newModel);
+                        }
+                        // If model already exists, setValue above already handled it
+                    }
+                }
 
                 setLanguages((prev) =>
                     (prev ?? []).map((lang) => ({
@@ -297,7 +324,7 @@ export default function useTaskTemplateEditPage(taskTemplateId: string) {
                 toast.error((err as Error).message);
             }
         },
-        [languages, taskTemplateId]
+        [languages, taskTemplateId, activeFileTab, selectedLanguage]
     );
 
     const removeLanguage = useCallback(

--- a/src/lib/hooks/useTestRunner.ts
+++ b/src/lib/hooks/useTestRunner.ts
@@ -1,15 +1,25 @@
 import { useState } from 'react';
 import { runEditorSubmission, runAssessmentSubmission } from '@/lib/api/runner';
-import { type JudgeResultRequestBody } from '@/lib/connectors/judge0.connector';
 import { type ProgrammingLanguage } from '@/generated/prisma';
 import { type TestCaseDTO } from '@/lib/schemas/task-template.schema';
+import type { CandidateTestResult } from '@/lib/types/candidate-assessment.types';
 
-export default function useTestRunner(code: string, language: ProgrammingLanguage) {
-    const [error, setError] = useState<Error>();
+export default function useTestRunner() {
+    const [error, setError] = useState<Error | null>(null);
     const [loading, setLoading] = useState<boolean>(false);
-    const [output, setOutput] = useState<JudgeResultRequestBody>();
+    const [output, setOutput] = useState<CandidateTestResult[]>();
 
-    async function runEditPageTests(tests: TestCaseDTO[]) {
+    function reset() {
+        setError(null);
+        setLoading(false);
+        setOutput(undefined);
+    }
+
+    async function runEditPageTests(
+        tests: TestCaseDTO[],
+        code: string,
+        language: ProgrammingLanguage
+    ) {
         try {
             setLoading(true);
             const result = await runEditorSubmission({
@@ -18,7 +28,6 @@ export default function useTestRunner(code: string, language: ProgrammingLanguag
                 tests,
             });
             setOutput(result);
-            console.warn(result);
         } catch (err) {
             setError(err as Error);
         } finally {
@@ -26,7 +35,11 @@ export default function useTestRunner(code: string, language: ProgrammingLanguag
         }
     }
 
-    async function runAssessmentTests(taskTemplateId: string) {
+    async function runAssessmentTests(
+        taskTemplateId: string,
+        code: string,
+        language: ProgrammingLanguage
+    ) {
         try {
             setLoading(true);
             const result = await runAssessmentSubmission(taskTemplateId, {
@@ -44,6 +57,7 @@ export default function useTestRunner(code: string, language: ProgrammingLanguag
     return {
         runAssessmentTests,
         runEditPageTests,
+        reset,
         error,
         loading,
         output,

--- a/src/lib/schemas/assessment.schema.ts
+++ b/src/lib/schemas/assessment.schema.ts
@@ -10,11 +10,10 @@ export const assessmentSchema = z.object({
     assessmentTemplateId: z.string(),
     deadline: z.date().nullable(),
     assignedAt: z.date(),
-    uniqueLink: z.string(),
     submittedAt: z.date().nullable(),
 });
 
-export const createAssessmentSchema = assessmentSchema.omit({ id: true, uniqueLink: true });
+export const createAssessmentSchema = assessmentSchema.omit({ id: true });
 
 export const updateAssessmentSchema = assessmentSchema.partial().extend({
     id: z.string(),

--- a/src/lib/services/application.service.ts
+++ b/src/lib/services/application.service.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import { prisma } from '@/lib/prisma';
 import { NotFoundException, ForbiddenException } from '@/lib/utils/errors.utils';
 import { type AddApplicationWithCandidateDataDTO } from '@/lib/schemas/application.schema';
@@ -65,7 +64,6 @@ async function addApplicationToPosition(
                 data: {
                     applicationId: createdApplication.id,
                     assessmentTemplateId: position.assessmentId,
-                    uniqueLink: crypto.randomUUID(),
                 },
             });
 
@@ -93,7 +91,6 @@ async function addApplicationToPosition(
                 assessment: {
                     select: {
                         id: true,
-                        uniqueLink: true,
                         submittedAt: true,
                     },
                 },
@@ -184,7 +181,6 @@ async function batchAddApplicationsToPosition(
                         data: {
                             applicationId: application.id,
                             assessmentTemplateId,
-                            uniqueLink: crypto.randomUUID(),
                         },
                     });
 
@@ -218,7 +214,6 @@ async function batchAddApplicationsToPosition(
             assessment: {
                 select: {
                     id: true,
-                    uniqueLink: true,
                     submittedAt: true,
                 },
             },
@@ -270,7 +265,6 @@ async function getPositionApplications(
             assessment: {
                 select: {
                     id: true,
-                    uniqueLink: true,
                     submittedAt: true,
                 },
             },

--- a/src/lib/services/assessment.service.ts
+++ b/src/lib/services/assessment.service.ts
@@ -245,6 +245,13 @@ async function getAssessmentForCandidate(assessmentId: string): Promise<Candidat
                     candidate: {
                         select: { name: true, email: true },
                     },
+                    position: {
+                        select: {
+                            organization: {
+                                select: { name: true },
+                            },
+                        },
+                    },
                 },
             },
             assessmentTemplate: {
@@ -290,6 +297,7 @@ async function getAssessmentForCandidate(assessmentId: string): Promise<Candidat
         submittedAt: assessment.submittedAt,
         assessmentStatus: assessment.application.assessmentStatus,
         candidateName: assessment.application.candidate.name,
+        organizationName: assessment.application.position.organization.name,
         candidateEmail: assessment.application.candidate.email,
         assessmentTemplate: {
             title: assessment.assessmentTemplate.title,

--- a/src/lib/services/assessment.service.ts
+++ b/src/lib/services/assessment.service.ts
@@ -75,17 +75,12 @@ async function createAssessment(
             `Assessment Template with id ${assessment.assessmentTemplateId} not found`
         );
     }
-    // the unique link shouldn't be the full link (bc the env of the link matters) so we just use id
     const id = crypto.randomUUID();
     const newAssessment = await prisma.assessment.create({
-        data: { ...assessment, id, uniqueLink: id },
+        data: { ...assessment, id },
     });
 
     return newAssessment;
-}
-
-function buildAssessmentLinkToken() {
-    return crypto.randomUUID();
 }
 
 async function assignTemplateToPosition(params: {
@@ -165,7 +160,6 @@ async function assignTemplateToPosition(params: {
                 data: {
                     applicationId: application.id,
                     assessmentTemplateId,
-                    uniqueLink: buildAssessmentLinkToken(),
                 },
             });
 

--- a/src/lib/services/candidate.service.ts
+++ b/src/lib/services/candidate.service.ts
@@ -72,7 +72,6 @@ async function addCandidateToPosition(
             assessment: {
                 select: {
                     id: true,
-                    uniqueLink: true,
                     submittedAt: true,
                 },
             },
@@ -149,7 +148,6 @@ async function batchAddCandidatesToPosition(
             assessment: {
                 select: {
                     id: true,
-                    uniqueLink: true,
                     submittedAt: true,
                 },
             },
@@ -198,7 +196,6 @@ async function getPositionCandidates(
             assessment: {
                 select: {
                     id: true,
-                    uniqueLink: true,
                     submittedAt: true,
                 },
             },

--- a/src/lib/services/email.service.ts
+++ b/src/lib/services/email.service.ts
@@ -47,7 +47,7 @@ export async function sendAssessmentInvitationEmail(
 
     const baseUrl =
         process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
-    const assessmentUrl = `${baseUrl}/assessment/${assessment.uniqueLink}`;
+    const assessmentUrl = `${baseUrl}/assessment/${assessment.id}`;
     const logoUrl = `${baseUrl}/Sarge_logo.svg`;
 
     //placeholder duration and expiration

--- a/src/lib/services/email.service.ts
+++ b/src/lib/services/email.service.ts
@@ -19,7 +19,21 @@ export async function sendAssessmentInvitationEmail(
         include: {
             applications: {
                 include: {
-                    assessment: true,
+                    assessment: {
+                        include: {
+                            assessmentTemplate: {
+                                include: {
+                                    tasks: {
+                                        include: {
+                                            taskTemplate: {
+                                                select: { estimatedTime: true },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
                     position: true,
                 },
             },
@@ -51,7 +65,10 @@ export async function sendAssessmentInvitationEmail(
     const logoUrl = `${baseUrl}/Sarge_logo.svg`;
 
     //placeholder duration and expiration
-    const durationMinutes = 120;
+    const durationMinutes = assessment.assessmentTemplate.tasks.reduce(
+        (sum, task) => sum + task.taskTemplate.estimatedTime,
+        0
+    );
     const expirationDate = 'April 12, 2026 11:59PM EST';
     const htmlContent = generateAssessmentInvitationHTML({
         candidateName: candidate.name,

--- a/src/lib/services/email.service.ts
+++ b/src/lib/services/email.service.ts
@@ -52,7 +52,7 @@ export async function sendAssessmentInvitationEmail(
 
     //placeholder duration and expiration
     const durationMinutes = 120;
-    const expirationDate = 'March 16, 2026 11:59PM EST';
+    const expirationDate = 'April 12, 2026 11:59PM EST';
     const htmlContent = generateAssessmentInvitationHTML({
         candidateName: candidate.name,
         positionTitle: position.title,

--- a/src/lib/services/position.service.ts
+++ b/src/lib/services/position.service.ts
@@ -138,7 +138,6 @@ async function getPositionPreview(positionId: string, orgId: string): Promise<Po
                     assessment: {
                         select: {
                             id: true,
-                            uniqueLink: true,
                             submittedAt: true,
                             assessmentTemplate: {
                                 select: {
@@ -206,7 +205,6 @@ async function getPositionPreview(positionId: string, orgId: string): Promise<Po
             assessment: app.assessment
                 ? {
                       id: app.assessment.id,
-                      uniqueLink: app.assessment.uniqueLink,
                       submittedAt: app.assessment.submittedAt,
                       reviews: app.assessment.reviews.map((review) => ({
                           reviewer: review.reviewer,

--- a/src/lib/templates/invitation.ts
+++ b/src/lib/templates/invitation.ts
@@ -20,7 +20,7 @@ export function generateAssessmentInvitationHTML(data: AssessmentInvitationEmail
     </head>
     <body style="margin: 0; padding: 20px; background-color: #f5f5f5; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;">
         <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; border: 1px solid #e5e5e7; border-radius: 12px; overflow: hidden;">
-            
+
             <!-- Header -->
             <div style="background-color: #4D38EF; padding: 24px; display: flex; align-items: flex-end; justify-content: space-between; gap: 20px;">
                 <div style="flex: 1;">
@@ -34,7 +34,7 @@ export function generateAssessmentInvitationHTML(data: AssessmentInvitationEmail
             <!-- Body -->
             <div style="padding: 32px 24px; color: #000000;">
                 <p style="margin: 0 0 16px 0; font-size: 16px; line-height: 1.5;">Hello ${data.candidateName},</p>
-                
+
                 <p style="margin: 0 0 24px 0; font-size: 14px; line-height: 1.6; color: #333333;">
                     Thank you for your application and interest in ${data.organizationName}! The first step in our application process is a coding assessment to evaluate your technical and problem-solving skills.
                 </p>
@@ -59,8 +59,8 @@ export function generateAssessmentInvitationHTML(data: AssessmentInvitationEmail
                 </div>
 
                 <div style="text-align: center; margin: 0 0 24px 0;">
-                    <a 
-                        href="/assessment/${data.assessmentId}" 
+                    <a
+                        href="${data.assessmentUrl}"
                         style="display: inline-block; background-color: #5D5BF7; color: white; font-weight: 500; padding: 12px 28px; text-decoration: none; border-radius: 8px; font-size: 15px;"
                     >
                         Open Assessment

--- a/src/lib/templates/invitation.ts
+++ b/src/lib/templates/invitation.ts
@@ -69,7 +69,7 @@ export function generateAssessmentInvitationHTML(data: AssessmentInvitationEmail
 
                 <div style="text-align: center; font-size: 14px; color: #333333; margin: 0 0 16px 0;">
                     <p style="margin: 0;">
-                        You can also use <a href="/assessment/${data.assessmentId}" style="color: #4D38EF; text-decoration: underline; font-weight: 600;">this link</a> to access your assessment. Visiting this link will not begin the assessment.
+                        You can also use <a href=${data.assessmentUrl}" style="color: #4D38EF; text-decoration: underline; font-weight: 600;">this link</a> to access your assessment. Visiting this link will not begin the assessment.
                     </p>
                 </div>
             </div>

--- a/src/lib/types/candidate-assessment.types.ts
+++ b/src/lib/types/candidate-assessment.types.ts
@@ -31,6 +31,7 @@ export type CandidateAssessment = {
     submittedAt: Date | null;
     assessmentStatus: AssessmentStatus;
     candidateName: string;
+    organizationName: string;
     candidateEmail: string;
     assessmentTemplate: {
         title: string;

--- a/src/lib/types/candidate-assessment.types.ts
+++ b/src/lib/types/candidate-assessment.types.ts
@@ -41,9 +41,27 @@ export type CandidateAssessment = {
 export type AssessmentPhase = 'intro' | 'assessment' | 'outro';
 export type OutroReason = 'submitted' | 'expired';
 export type SectionStatus = 'locked' | 'current' | 'completed';
+export type TestCaseResultStatus =
+    | 'default'
+    | 'loading'
+    | 'passed'
+    | 'failed'
+    | 'runtime_error'
+    | 'error';
+
+/**
+ * CandidateTestResult represents the parsed and normalized test result returned to the frontend.
+ * It is distinct from TestCaseResult which is used to track the UI state of a test case.
+ */
+export type CandidateTestResult = {
+    stdout: string;
+    stderr: string;
+    description: string;
+    statusId: number;
+};
 
 export type TestCaseResult = {
-    status: 'default' | 'loading' | 'passed' | 'failed' | 'runtime_error';
+    status: TestCaseResultStatus;
     actualOutput?: string;
 };
 

--- a/src/lib/types/position.types.ts
+++ b/src/lib/types/position.types.ts
@@ -26,7 +26,6 @@ export interface ApplicationDisplayInfo {
     };
     assessment: {
         id: string;
-        uniqueLink: string;
         submittedAt: Date | null;
     } | null;
     grader: {
@@ -55,7 +54,6 @@ export interface PositionPreviewCandidate {
     };
     assessment: {
         id: string;
-        uniqueLink: string;
         submittedAt: Date | null;
         reviews: {
             reviewer: {
@@ -106,7 +104,6 @@ export interface PositionPreviewResponse {
         };
         assessment: {
             id: string;
-            uniqueLink: string;
             submittedAt: string | null;
             reviews: {
                 reviewer: {

--- a/src/lib/utils/language.utils.ts
+++ b/src/lib/utils/language.utils.ts
@@ -118,6 +118,285 @@ function normalizeTypeForLanguage(
     return SIMPLE_TYPE_ALIASES[language][lowerType];
 }
 
+function toStdoutFunction(
+    value: string,
+    returnType: string,
+    language: 'python' | 'javascript' | 'typescript' | 'c' | 'cpp' | 'ruby'
+): string {
+    const normalized = normalizeTypeKey(returnType);
+    const isArray = normalized.endsWith('[]');
+
+    switch (language) {
+        case 'python':
+            if (isArray) return `print(json.dumps(${value}, separators=(',', ':')))`;
+            if (normalized === 'bool') return `print(str(${value}).lower())`;
+            return `print(${value})`;
+        case 'javascript':
+        case 'typescript':
+            if (normalized === 'string' || normalized === 'char') return `console.log(${value});`;
+            return `console.log(JSON.stringify(${value}));`;
+        case 'ruby':
+            return `puts ${value}.inspect`;
+        case 'c':
+            if (isArray) return `// serialize array then fputs to stdout`;
+            if (normalized === 'string') return `printf("%s\\n", ${value});`;
+            if (normalized === 'float') return `printf("%f\\n", ${value});`;
+            if (normalized === 'bool') return `printf("%s\\n", ${value} ? "true" : "false");`;
+            return `printf("%d\\n", ${value});`;
+        case 'cpp':
+            if (isArray)
+                return `for (auto& x : ${value}) std::cout << x << ' '; std::cout << '\\n';`;
+            if (normalized === 'bool') return `std::cout << std::boolalpha << ${value} << '\\n';`;
+            return `std::cout << ${value} << '\\n';`;
+    }
+}
+
+function pythonParseExpr(type: string, lineExpr: string): string {
+    const normalized = normalizeTypeKey(type);
+    if (normalized.endsWith('[]')) return `json.loads(${lineExpr})`;
+    switch (normalized) {
+        case 'int':
+            return `int(${lineExpr})`;
+        case 'float':
+            return `float(${lineExpr})`;
+        case 'bool':
+            return `${lineExpr}.strip() == 'true'`;
+        case 'string':
+        case 'char':
+            return lineExpr;
+        default:
+            return lineExpr;
+    }
+}
+
+function jsParseExpr(type: string, lineExpr: string): string {
+    const normalized = normalizeTypeKey(type);
+    if (normalized.endsWith('[]')) return `JSON.parse(${lineExpr})`;
+    switch (normalized) {
+        case 'int':
+        case 'float':
+            return `Number(${lineExpr})`;
+        case 'bool':
+            return `JSON.parse(${lineExpr})`;
+        case 'string':
+        case 'char':
+            return lineExpr;
+        default:
+            return lineExpr;
+    }
+}
+
+function rubyParseExpr(type: string, lineExpr: string): string {
+    const normalized = normalizeTypeKey(type);
+    if (normalized.endsWith('[]')) return `JSON.parse(${lineExpr})`;
+    switch (normalized) {
+        case 'int':
+            return `${lineExpr}.to_i`;
+        case 'float':
+            return `${lineExpr}.to_f`;
+        case 'bool':
+            return `${lineExpr}.strip == 'true'`;
+        case 'string':
+        case 'char':
+            return lineExpr;
+        default:
+            return lineExpr;
+    }
+}
+
+function cScanLines(varName: string, type: string): string[] {
+    const normalized = normalizeTypeKey(type);
+    if (normalized.endsWith('[]')) {
+        return [
+            `    ${normalizeTypeForLanguage(type, 'c')} ${varName}; /* TODO: parse array from stdin */`,
+        ];
+    }
+    switch (normalized) {
+        // NOTE(laith): both C and C++ implementations require 4 space indenting to be put inside the main function)
+        case 'int':
+            return [`    int ${varName}; scanf("%d", &${varName});`];
+        case 'float':
+            return [`    float ${varName}; scanf("%f", &${varName});`];
+        case 'bool':
+            return [
+                `    char _s_${varName}[8]; scanf("%7s", _s_${varName});`,
+                `    bool ${varName} = (strcmp(_s_${varName}, "true") == 0);`,
+            ];
+        case 'char':
+            return [`    char ${varName}; scanf(" %c", &${varName});`];
+        case 'string':
+            return [
+                `    char ${varName}[4096];`,
+                `    if (fgets(${varName}, sizeof(${varName}), stdin)) { ${varName}[strcspn(${varName}, "\\n")] = 0; }`,
+            ];
+        default: {
+            const cType = normalizeTypeForLanguage(type, 'c');
+            return [`    ${cType} ${varName}; /* TODO: parse from stdin */`];
+        }
+    }
+}
+
+function cppCinLines(varName: string, type: string): string[] {
+    const normalized = normalizeTypeKey(type);
+    const cppType = normalizeTypeForLanguage(type, 'cpp');
+    if (normalized.endsWith('[]')) {
+        return [`    ${cppType} ${varName}; /* TODO: parse array from stdin */`];
+    }
+    switch (normalized) {
+        case 'int':
+        case 'float':
+        case 'char':
+            return [`    ${cppType} ${varName}; std::cin >> ${varName};`];
+        case 'bool':
+            return [
+                `    ${cppType} ${varName};`,
+                `    { std::string _s; std::cin >> _s; ${varName} = (_s == "true"); }`,
+            ];
+        case 'string':
+            return [
+                `    ${cppType} ${varName};`,
+                `    std::getline(std::cin >> std::ws, ${varName});`,
+            ];
+        default:
+            return [`    ${cppType} ${varName}; /* TODO: parse from stdin */`];
+    }
+}
+
+function generatePythonToStdOut(
+    functionName: string,
+    returnType: string,
+    parameters: StubParameter[]
+): string {
+    const hasArray =
+        parameters.some((p) => normalizeTypeKey(p.type).endsWith('[]')) ||
+        normalizeTypeKey(returnType).endsWith('[]');
+    const imports = hasArray ? 'import json\nimport sys' : 'import sys';
+    const args = parameters.map((p) => p.name).join(', ');
+    const paramLines = parameters.map(
+        (p, i) => `    ${p.name} = ${pythonParseExpr(p.type, `_lines[${i}]`)}`
+    );
+    const print = toStdoutFunction('result', returnType, 'python');
+    return [
+        '# Do not edit below',
+        imports,
+        '',
+        'if __name__ == "__main__":',
+        "    _lines = sys.stdin.read().split('\\n')",
+        ...paramLines,
+        `    result = ${functionName}(${args})`,
+        `    ${print}`,
+    ].join('\n');
+}
+
+function generateJavaScriptToStdOut(
+    functionName: string,
+    returnType: string,
+    parameters: StubParameter[]
+): string {
+    const args = parameters.map((p) => p.name).join(', ');
+    const paramLines = parameters.map(
+        (p, i) => `const ${p.name} = ${jsParseExpr(p.type, `_lines[${i}]`)};`
+    );
+    const print = toStdoutFunction('result', returnType, 'javascript');
+    return [
+        '// Do not edit below',
+        `const _lines = require('fs').readFileSync('/dev/stdin', 'utf8').split('\\n');`,
+        ...paramLines,
+        `const result = ${functionName}(${args});`,
+        print,
+    ].join('\n');
+}
+
+function generateTypeScriptToStdOut(
+    functionName: string,
+    returnType: string,
+    parameters: StubParameter[]
+): string {
+    return generateJavaScriptToStdOut(functionName, returnType, parameters);
+}
+
+function generateRubyToStdOut(
+    functionName: string,
+    returnType: string,
+    parameters: StubParameter[]
+): string {
+    const hasArray = parameters.some((p) => normalizeTypeKey(p.type).endsWith('[]'));
+    const args = parameters.map((p) => p.name).join(', ');
+    const paramLines = parameters.map(
+        (p, i) => `${p.name} = ${rubyParseExpr(p.type, `_lines[${i}]`)}`
+    );
+    const print = toStdoutFunction('result', returnType, 'ruby');
+    const lines = ['# Do not edit below\n'];
+    if (hasArray) lines.push("require 'json'");
+    lines.push('_lines = $stdin.read.split("\\n")');
+    lines.push(...paramLines);
+    lines.push(`result = ${functionName}(${args})`);
+    lines.push(print);
+    return lines.join('\n');
+}
+
+function generateCToStdOut(
+    functionName: string,
+    returnType: string,
+    parameters: StubParameter[]
+): string {
+    const args = parameters.map((p) => p.name).join(', ');
+    const paramLines = parameters.flatMap((p) => cScanLines(p.name, p.type));
+    const print = toStdoutFunction('result', returnType, 'c');
+    return [
+        '// Do not edit below',
+        'int main(void) {',
+        ...paramLines,
+        `    ${normalizeTypeForLanguage(returnType, 'c')} result = ${functionName}(${args});`,
+        `    ${print}`,
+        '    return 0;',
+        '}',
+    ].join('\n');
+}
+
+function generateCppToStdOut(
+    functionName: string,
+    returnType: string,
+    parameters: StubParameter[]
+): string {
+    const args = parameters.map((p) => p.name).join(', ');
+    const paramLines = parameters.flatMap((p) => cppCinLines(p.name, p.type));
+    const print = toStdoutFunction('result', returnType, 'cpp');
+    return [
+        '// Do not edit below',
+        'int main() {',
+        ...paramLines,
+        `    auto result = ${functionName}(${args});`,
+        `    ${print}`,
+        '    return 0;',
+        '}',
+    ].join('\n');
+}
+
+export function generateStdOutCode(
+    functionName: string,
+    returnType: string,
+    parameters: StubParameter[],
+    language: string
+): string {
+    switch (language) {
+        case 'python':
+            return generatePythonToStdOut(functionName, returnType, parameters);
+        case 'javascript':
+            return generateJavaScriptToStdOut(functionName, returnType, parameters);
+        case 'typescript':
+            return generateTypeScriptToStdOut(functionName, returnType, parameters);
+        case 'ruby':
+            return generateRubyToStdOut(functionName, returnType, parameters);
+        case 'c':
+            return generateCToStdOut(functionName, returnType, parameters);
+        case 'cpp':
+            return generateCppToStdOut(functionName, returnType, parameters);
+        default:
+            return `// stdout conversion for ${language} is not supported.`;
+    }
+}
+
 function generatePythonCodeStub(
     functionName: string,
     returnType: string,
@@ -167,7 +446,7 @@ function generateCCodeStub(
         .map((parameter) => `${normalizeTypeForLanguage(parameter.type, 'c')} ${parameter.name}`)
         .join(', ');
 
-    return `${normalizeTypeForLanguage(returnType, 'c')} ${functionName}(${cParams || 'void'}) {\n    // TODO: implement\n}`;
+    return `#include <stdio.h>\n#include <string.h>\n#include <stdbool.h>\n\n${normalizeTypeForLanguage(returnType, 'c')} ${functionName}(${cParams || 'void'}) {\n    // TODO: implement\n}`;
 }
 
 function generateCppCodeStub(
@@ -179,7 +458,7 @@ function generateCppCodeStub(
         .map((parameter) => `${normalizeTypeForLanguage(parameter.type, 'cpp')} ${parameter.name}`)
         .join(', ');
 
-    return `${normalizeTypeForLanguage(returnType, 'cpp')} ${functionName}(${cppParams}) {\n    // TODO: implement\n}`;
+    return `#include <iostream>\n#include <string>\n#include <vector>\n\n${normalizeTypeForLanguage(returnType, 'cpp')} ${functionName}(${cppParams}) {\n    // TODO: implement\n}`;
 }
 
 export function generateCodeStub(
@@ -188,44 +467,49 @@ export function generateCodeStub(
     parameters: StubParameter[],
     language: string
 ): string {
+    let stub: string;
     switch (language) {
         case 'python':
-            return generatePythonCodeStub(functionName, returnType, parameters);
+            stub = generatePythonCodeStub(functionName, returnType, parameters);
+            break;
         case 'javascript':
-            return generateJavaScriptCodeStub(functionName, parameters);
+            stub = generateJavaScriptCodeStub(functionName, parameters);
+            break;
         case 'ruby':
-            return generateRubyCodeStub(functionName, parameters);
+            stub = generateRubyCodeStub(functionName, parameters);
+            break;
         case 'typescript':
-            return generateTypeScriptCodeStub(functionName, returnType, parameters);
+            stub = generateTypeScriptCodeStub(functionName, returnType, parameters);
+            break;
         case 'c':
-            return generateCCodeStub(functionName, returnType, parameters);
+            stub = generateCCodeStub(functionName, returnType, parameters);
+            break;
         case 'cpp':
-            return generateCppCodeStub(functionName, returnType, parameters);
+            stub = generateCppCodeStub(functionName, returnType, parameters);
+            break;
         default:
             return `// Code stub for ${language} is not available.`;
     }
+
+    const conversionFunction = generateStdOutCode(functionName, returnType, parameters, language);
+    return `${stub}\n\n${conversionFunction}`;
 }
 
 export function mapLanguageToJudge(language: string): number {
-    try {
-        switch (language) {
-            case 'python':
-                return 100;
-            case 'javascript':
-                return 102;
-            case 'ruby':
-                return 72;
-            case 'typescript':
-                return 101;
-            case 'c':
-                return 103;
-            case 'cpp':
-                return 105;
-            default:
-                return -1;
-        }
-    } catch {
-        // figure this out later
-        throw new Error('language not foudn');
+    switch (language) {
+        case 'python':
+            return 100;
+        case 'javascript':
+            return 102;
+        case 'ruby':
+            return 72;
+        case 'typescript':
+            return 101;
+        case 'c':
+            return 103;
+        case 'cpp':
+            return 105;
+        default:
+            return -1;
     }
 }

--- a/src/lib/utils/token.utils.ts
+++ b/src/lib/utils/token.utils.ts
@@ -1,7 +1,7 @@
 import { SignJWT } from 'jose';
 
 export async function generateToken(email: string) {
-    const secret = new TextEncoder().encode('SECRET');
+    const secret = new TextEncoder().encode(process.env.JWT_SECRET);
 
     const jwt = await new SignJWT({ email })
         .setProtectedHeader({ alg: 'HS256' })

--- a/src/ws/index.js
+++ b/src/ws/index.js
@@ -2,7 +2,7 @@ import { WebSocketServer } from 'ws';
 import { jwtVerify } from 'jose';
 
 const ws = new WebSocketServer({ port: 8080 });
-const secret = new TextEncoder().encode('SECRET');
+const secret = new TextEncoder().encode(process.env.JWT_SECRET);
 
 console.log('Sarge WS server listening on 8080');
 
@@ -46,6 +46,7 @@ ws.on('connection', async (socket, request) => {
         clients.set(payload.candidateEmail, socket);
     } catch {
         socket.close(1008, 'Unauthorized');
+        console.log(`[${new Date().toISOString()}] Unauthorized connection. Closing.`);
         return;
     }
 

--- a/src/ws/index.js
+++ b/src/ws/index.js
@@ -2,7 +2,7 @@ import { WebSocketServer } from 'ws';
 import { jwtVerify } from 'jose';
 
 const ws = new WebSocketServer({ port: 8080 });
-const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+const secret = new TextEncoder().encode('SECRET');
 
 console.log('Sarge WS server listening on 8080');
 

--- a/src/ws/package.json
+++ b/src/ws/package.json
@@ -5,8 +5,8 @@
     "main": "index.js",
     "type": "module",
     "scripts": {
-        "start": "node index.js",
-        "dev": "nodemon index.js"
+        "start": "node --env-file ../../.env index.js",
+        "dev": "nodemon --exec 'node --env-file ../../.env' index.js"
     },
     "keywords": [],
     "author": "",


### PR DESCRIPTION
# [OA] - Intro and Outro Sections

## Changes

Updated what the candidate sees in the assessment flow for intro and outro to current designs. The candidate cannot start the assessment until they agree to complete the assessment independently.

## Notes

Modified the assessment in intro props to return the organization name. In the outro section, the button is meant to close the tab, but a restriction is built into browsers for security reasons that a page can't close itself (unless it was opened by JavaScript). I looked and apparently other OA platforms just have a message that it's safe to close the tab so I added that. Also, the design had an organization level email but organizations don't have emails.

## Screenshots

<img width="1331" height="765" alt="Screen Shot 2026-04-08 at 10 48 16 PM" src="https://github.com/user-attachments/assets/ca56badd-4009-46cc-a2c7-9aa4d5ba37d0" />

<img width="1343" height="767" alt="Screen Shot 2026-04-08 at 10 52 07 PM" src="https://github.com/user-attachments/assets/97f4542b-2da9-4c3a-85a9-bfc3cf1c8a5d" />

## Closes

Closes #275 
