### PR TITLE
274/assessment flow submission

### DIFF
--- a/prisma/migrations/20260410013547_add_started_at_and_default_estimated_time/migration.sql
+++ b/prisma/migrations/20260410013547_add_started_at_and_default_estimated_time/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "public"."Assessment" ADD COLUMN     "startedAt" TIMESTAMP(3);
+
+-- Backfill existing tasks with 0 estimated time to the new default
+UPDATE "public"."TaskTemplate" SET "estimatedTime" = 30 WHERE "estimatedTime" = 0;
+
+-- AlterTable
+ALTER TABLE "public"."TaskTemplate" ALTER COLUMN "estimatedTime" SET DEFAULT 30;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -155,7 +155,7 @@ model TaskTemplate {
   orgId            String
   taskType         String?
   authorId         String
-  estimatedTime    Int     @default(0)
+  estimatedTime    Int     @default(30)
   timeout          Int     @default(0)
 
   organization Organization           @relation(fields: [orgId], references: [id])
@@ -224,6 +224,7 @@ model Assessment {
   assessmentTemplateId String
   assignedAt           DateTime  @default(now())
   submittedAt          DateTime?
+  startedAt            DateTime?
   uniqueLink           String    @unique
   deadline             DateTime?
 

--- a/src/app/api/oa/[assessmentId]/start/route.ts
+++ b/src/app/api/oa/[assessmentId]/start/route.ts
@@ -1,0 +1,16 @@
+import AssessmentService from '@/lib/services/assessment.service';
+import { handleError } from '@/lib/utils/errors.utils';
+import { type NextRequest } from 'next/server';
+
+export async function PUT(
+    _request: NextRequest,
+    { params }: { params: Promise<{ assessmentId: string }> }
+) {
+    try {
+        const { assessmentId } = await params;
+        await AssessmentService.startAssessmentForCandidate(assessmentId);
+        return Response.json({ data: null }, { status: 200 });
+    } catch (err) {
+        return handleError(err);
+    }
+}

--- a/src/lib/api/candidate-assessment.ts
+++ b/src/lib/api/candidate-assessment.ts
@@ -21,3 +21,14 @@ export async function submitCandidateAssessment(assessmentId: string): Promise<v
 
     return json.data;
 }
+
+export async function startCandidateAssessment(assessmentId: string): Promise<void> {
+    const res = await fetch(`/api/oa/${assessmentId}/start`, { method: 'PUT' });
+    const json = await res.json();
+
+    if (!res.ok) {
+        throw new Error(json.message);
+    }
+
+    return json.data;
+}

--- a/src/lib/components/assessment-flow/AssessmentOutro.tsx
+++ b/src/lib/components/assessment-flow/AssessmentOutro.tsx
@@ -9,6 +9,19 @@ type AssessmentOutroProps = {
 
 export default function AssessmentOutro({ reason, candidateName }: AssessmentOutroProps) {
     const isExpired = reason === 'expired';
+    const isAlreadyStarted = reason === 'already_started';
+
+    const heading = isAlreadyStarted
+        ? 'Assessment already in progress'
+        : isExpired
+          ? 'Your time is up'
+          : 'Assessment submitted!';
+
+    const description = isAlreadyStarted
+        ? 'This assessment was already started. Your work has been submitted.'
+        : isExpired
+          ? "Don't worry, we submitted your work."
+          : `Thank you for completing your assessment${candidateName ? `, ${candidateName}` : ''}.`;
 
     return (
         <div className="bg-sarge-gray-50 flex h-full items-center justify-center p-8">
@@ -22,14 +35,8 @@ export default function AssessmentOutro({ reason, candidateName }: AssessmentOut
                 />
 
                 <div>
-                    <h1 className="text-sarge-gray-800 text-2xl font-semibold">
-                        {isExpired ? 'Your time is up' : 'Assessment submitted!'}
-                    </h1>
-                    <p className="text-sarge-gray-500 mt-2 text-sm">
-                        {isExpired
-                            ? "Don't worry, we submitted your work."
-                            : `Thank you for completing your assessment${candidateName ? `, ${candidateName}` : ''}.`}
-                    </p>
+                    <h1 className="text-display-s">{heading}</h1>
+                    <p className="text-body-s text-sarge-gray-500 mt-2">{description}</p>
                 </div>
 
                 <Link

--- a/src/lib/hooks/useAssessment.ts
+++ b/src/lib/hooks/useAssessment.ts
@@ -4,7 +4,11 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { type editor } from 'monaco-editor';
 import { type Monaco } from '@monaco-editor/react';
 import { toast } from 'sonner';
-import { getCandidateAssessment, submitCandidateAssessment } from '@/lib/api/candidate-assessment';
+import {
+    getCandidateAssessment,
+    submitCandidateAssessment,
+    startCandidateAssessment,
+} from '@/lib/api/candidate-assessment';
 import { useAssessmentTimer } from '@/lib/hooks/useAssessmentTimer';
 import type {
     AssessmentPhase,
@@ -54,7 +58,7 @@ export default function useAssessment(assessmentId: string) {
 
     // the timer is in seconds however our model is in minutes
     const totalEstimatedMinutes = sections.reduce(
-        (sum, s) => sum + (s.taskTemplate.estimatedTime ?? 0),
+        (sum, s) => sum + s.taskTemplate.estimatedTime,
         0
     );
     const totalTimeSeconds = totalEstimatedMinutes * 60;
@@ -69,7 +73,16 @@ export default function useAssessment(assessmentId: string) {
                 const token = await createToken(data.candidateEmail);
                 setAssessment(data);
                 setToken(token);
-                setSections(buildInitialSections(data.assessmentTemplate.tasks));
+
+                if (data.startedAt) {
+                    setOutroReason('already_started');
+                    setPhase('outro');
+                    if (!data.submittedAt) {
+                        await submitCandidateAssessment(assessmentId);
+                    }
+                } else {
+                    setSections(buildInitialSections(data.assessmentTemplate.tasks));
+                }
             } catch (err) {
                 setError(err as Error);
             } finally {
@@ -103,8 +116,13 @@ export default function useAssessment(assessmentId: string) {
         }
     }, [timer.isExpired, phase, handleSubmitAssessment]);
 
-    function startAssessment() {
-        setPhase('assessment');
+    async function startAssessment() {
+        try {
+            await startCandidateAssessment(assessmentId);
+            setPhase('assessment');
+        } catch (err) {
+            toast.error(`Failed to start assessment. Please try again. Error: ${err}`);
+        }
     }
 
     function submitAndContinue() {
@@ -174,11 +192,11 @@ export default function useAssessment(assessmentId: string) {
             prev.map((s, i) =>
                 i === currentSectionIndex
                     ? {
-                          ...s,
-                          testCaseResults: s.testCaseResults.map(() => ({
-                              status: 'loading' as const,
-                          })),
-                      }
+                        ...s,
+                        testCaseResults: s.testCaseResults.map(() => ({
+                            status: 'loading' as const,
+                        })),
+                    }
                     : s
             )
         );

--- a/src/lib/hooks/useAssessment.ts
+++ b/src/lib/hooks/useAssessment.ts
@@ -74,12 +74,12 @@ export default function useAssessment(assessmentId: string) {
                 setAssessment(data);
                 setToken(token);
 
-                if (data.startedAt) {
+                if (data.submittedAt) {
+                    setOutroReason('submitted');
+                    setPhase('outro');
+                } else if (data.startedAt) {
                     setOutroReason('already_started');
                     setPhase('outro');
-                    if (!data.submittedAt) {
-                        await submitCandidateAssessment(assessmentId);
-                    }
                 } else {
                     setSections(buildInitialSections(data.assessmentTemplate.tasks));
                 }

--- a/src/lib/hooks/useAssessment.ts
+++ b/src/lib/hooks/useAssessment.ts
@@ -192,11 +192,11 @@ export default function useAssessment(assessmentId: string) {
             prev.map((s, i) =>
                 i === currentSectionIndex
                     ? {
-                        ...s,
-                        testCaseResults: s.testCaseResults.map(() => ({
-                            status: 'loading' as const,
-                        })),
-                    }
+                          ...s,
+                          testCaseResults: s.testCaseResults.map(() => ({
+                              status: 'loading' as const,
+                          })),
+                      }
                     : s
             )
         );

--- a/src/lib/schemas/assessment.schema.ts
+++ b/src/lib/schemas/assessment.schema.ts
@@ -12,6 +12,7 @@ export const assessmentSchema = z.object({
     assignedAt: z.date(),
     uniqueLink: z.string(),
     submittedAt: z.date().nullable(),
+    startedAt: z.date().nullable(),
 });
 
 export const createAssessmentSchema = assessmentSchema.omit({ id: true, uniqueLink: true });

--- a/src/lib/services/assessment.service.ts
+++ b/src/lib/services/assessment.service.ts
@@ -245,6 +245,7 @@ async function getAssessmentForCandidate(assessmentId: string): Promise<Candidat
             deadline: true,
             assignedAt: true,
             submittedAt: true,
+            startedAt: true,
             application: {
                 select: {
                     assessmentStatus: true,
@@ -294,6 +295,7 @@ async function getAssessmentForCandidate(assessmentId: string): Promise<Candidat
         deadline: assessment.deadline,
         assignedAt: assessment.assignedAt,
         submittedAt: assessment.submittedAt,
+        startedAt: assessment.startedAt,
         assessmentStatus: assessment.application.assessmentStatus,
         candidateName: assessment.application.candidate.name,
         candidateEmail: assessment.application.candidate.email,
@@ -409,9 +411,34 @@ async function sendAssessmentInvitationsToPosition(
     };
 }
 
+async function startAssessmentForCandidate(assessmentId: string): Promise<void> {
+    const assessment = await prisma.assessment.findFirst({
+        where: { id: assessmentId },
+        select: { id: true, startedAt: true, submittedAt: true },
+    });
+
+    if (!assessment) {
+        throw new NotFoundException('Assessment', assessmentId);
+    }
+
+    if (assessment.submittedAt) {
+        throw new BadRequestException('Assessment has already been submitted');
+    }
+
+    if (assessment.startedAt) {
+        throw new BadRequestException('Assessment has already been started');
+    }
+
+    await prisma.assessment.update({
+        where: { id: assessmentId },
+        data: { startedAt: new Date() },
+    });
+}
+
 const AssessmentService = {
     getAssessmentWithRelations,
     getAssessmentForCandidate,
+    startAssessmentForCandidate,
     submitAssessmentForCandidate,
     createAssessment,
     assignTemplateToPosition,

--- a/src/lib/services/email.service.ts
+++ b/src/lib/services/email.service.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import sesConnector from '@/lib/connectors/ses.connector';
 import { generateAssessmentInvitationHTML } from '@/lib/templates/invitation';
+import { formatDeadline } from '@/lib/utils/date.utils';
 
 interface SendAssessmentInvitationResult {
     success: boolean;
@@ -19,7 +20,21 @@ export async function sendAssessmentInvitationEmail(
         include: {
             applications: {
                 include: {
-                    assessment: true,
+                    assessment: {
+                        include: {
+                            assessmentTemplate: {
+                                include: {
+                                    tasks: {
+                                        include: {
+                                            taskTemplate: {
+                                                select: { estimatedTime: true },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
                     position: true,
                 },
             },
@@ -50,9 +65,11 @@ export async function sendAssessmentInvitationEmail(
     const assessmentUrl = `${baseUrl}/assessment/${assessment.uniqueLink}`;
     const logoUrl = `${baseUrl}/Sarge_logo.svg`;
 
-    //placeholder duration and expiration
-    const durationMinutes = 120;
-    const expirationDate = 'March 16, 2026 11:59PM EST';
+    const durationMinutes = assessment.assessmentTemplate.tasks.reduce(
+        (sum, task) => sum + task.taskTemplate.estimatedTime,
+        0
+    );
+    const expirationDate = formatDeadline(assessment.deadline);
     const htmlContent = generateAssessmentInvitationHTML({
         candidateName: candidate.name,
         positionTitle: position.title,

--- a/src/lib/types/candidate-assessment.types.ts
+++ b/src/lib/types/candidate-assessment.types.ts
@@ -29,6 +29,7 @@ export type CandidateAssessment = {
     deadline: Date | null;
     assignedAt: Date;
     submittedAt: Date | null;
+    startedAt: Date | null;
     assessmentStatus: AssessmentStatus;
     candidateName: string;
     candidateEmail: string;
@@ -39,7 +40,7 @@ export type CandidateAssessment = {
 };
 
 export type AssessmentPhase = 'intro' | 'assessment' | 'outro';
-export type OutroReason = 'submitted' | 'expired';
+export type OutroReason = 'submitted' | 'expired' | 'already_started';
 export type SectionStatus = 'locked' | 'current' | 'completed';
 
 export type TestCaseResult = {


### PR DESCRIPTION
# [Area] - Short Description

## Changes

adds a started at to the schema for assessments (marks when a candidate started the assessment 
- added a route to start the assessment which sets the started at datetime (similar to how we have the submit route)

adds defaults to estimated time for tasks 
- removed some fallback logic for this field thats no longer needed


Modified the assessment hook and outro component 

if a user tries to take/open the assessment after it has already been started, it will take them to the outro screen saying that it was already started 

if the user refreshes, it will take them to the assessment outro screen (personally, I think this shouldn't be a thing but its what font wanted) it isn't great ux from a candidate perspective (I mean, accidents can happen where you refresh but I can see why he wants it this way)


https://sandboxneu.slack.com/archives/C09E7L2RK16/p1775786904833199?thread_ts=1775786778.858239&cid=C09E7L2RK16

## Checklist

Please go through all items before requesting reviewers:

- [ ] All commits are tagged with the ticket number
- [ ] No linting errors / newline warnings
- [ ] All code follows repository-configured formatting
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Screenshots included for UI changes
- [ ] Remove non-applicable sections of this template
- [ ] PR assigned to yourself
- [ ] Reviewers requested & Slack ping sent
- [ ] PR linked to the issue (fill in 'Closes #')
- [ ] If design-related, notify the designer in Slack

---

## Closes

Closes #274 
