### PR TITLE
[Install/CRM][Fullstack] - Sarge Admin Sign up Flow

### DIFF
--- a/prisma/migrations/20260609221851_add_superuser_role/migration.sql
+++ b/prisma/migrations/20260609221851_add_superuser_role/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "public"."Session" ADD COLUMN     "impersonatedBy" TEXT;
+
+-- AlterTable
+ALTER TABLE "public"."User" ADD COLUMN     "banExpires" TIMESTAMP(3),
+ADD COLUMN     "banReason" TEXT,
+ADD COLUMN     "banned" BOOLEAN DEFAULT false,
+ADD COLUMN     "role" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,8 @@ model Organization {
   taskTemplateTags    TaskTemplateTag[]
 }
 
-// An internal user of the Sarge platform (e.g. recruiter, reviewer, admin). Users authenticate and may belong to one or more organizations.
+// An internal user of the Sarge platform (e.g. recruiter, reviewer, admin). 
+// See the Member table for the specific role they hold. Users authenticate and may belong to one or more organizations.
 model User {
   id            String   @id @unique @default(cuid())
   name          String
@@ -37,6 +38,14 @@ model User {
   image         String?
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
+
+  // NOTE(laith): the fields below are required for better-auth's "admin" plugin.
+  // This is being used to handle superuser account creation. All fields should be null besides 'role' for the self-hosted superuser.
+  // The rest of the rows will be null/default until moderation is built into sarge.
+  role       String?
+  banned     Boolean?  @default(false)
+  banReason  String?
+  banExpires DateTime?
 
   reviews                     Review[]
   sessions                    Session[]
@@ -318,6 +327,9 @@ model Session {
   userAgent String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  // NOTE(laith): required for a better-auth plugin. Until we start using moderation features, leave null
+  impersonatedBy String?
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/prisma/seed-data/users.seed.ts
+++ b/prisma/seed-data/users.seed.ts
@@ -1,3 +1,10 @@
+export const superUserData = {
+    id: 'user_super_user_001',
+    name: 'Super User',
+    email: 'superuser@sargenu.com',
+    password: 'password123',
+};
+
 export const usersData = [
     {
         id: 'user_prof_fontenot_001',

--- a/prisma/seed-data/users.seed.ts
+++ b/prisma/seed-data/users.seed.ts
@@ -1,5 +1,5 @@
 export const superUserData = {
-    id: 'user_super_user_001',
+    id: 'user_superuser_001',
     name: 'Super User',
     email: 'superuser@sargenu.com',
     password: 'password123',

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/lib/auth/auth';
+import { SUPER_USER_ROLE } from '@/lib/auth/permissions';
 import { organizationsData } from './seed-data/organizations.seed';
 import { superUserData, usersData } from './seed-data/users.seed';
 import { invitationsSeedData } from './seed-data/invitations.seed';
@@ -68,7 +69,7 @@ async function seedSuperUser() {
     console.log('Seeding superuser...');
 
     const existingUser = await prisma.user.findUnique({
-        where: { id: superUserData.id },
+        where: { email: superUserData.email },
     });
 
     if (existingUser) {
@@ -87,9 +88,8 @@ async function seedSuperUser() {
     await prisma.user.update({
         where: { email: superUserData.email },
         data: {
-            id: superUserData.id,
             emailVerified: true,
-            role: 'superuser',
+            role: SUPER_USER_ROLE,
         },
     });
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,7 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/lib/auth/auth';
 import { organizationsData } from './seed-data/organizations.seed';
-import { usersData } from './seed-data/users.seed';
+import { superUserData, usersData } from './seed-data/users.seed';
 import { invitationsSeedData } from './seed-data/invitations.seed';
 import { positionsData } from './seed-data/positions.seed';
 import { candidatesData } from './seed-data/candidates.seed';
@@ -59,6 +59,41 @@ async function seedOrganizations() {
 
         console.log(`  Created organization: ${orgData.name}`);
     }
+}
+
+/*
+ * Seed Super User
+ */
+async function seedSuperUser() {
+    console.log('Seeding superuser...');
+
+    const existingUser = await prisma.user.findUnique({
+        where: { id: superUserData.id },
+    });
+
+    if (existingUser) {
+        console.log(`  User "${superUserData.name}" already exists`);
+        return;
+    }
+
+    await auth.api.signUpEmail({
+        body: {
+            name: superUserData.name,
+            email: superUserData.email,
+            password: superUserData.password,
+        },
+    });
+
+    await prisma.user.update({
+        where: { email: superUserData.email },
+        data: {
+            id: superUserData.id,
+            emailVerified: true,
+            role: 'superuser',
+        },
+    });
+
+    console.log(`  Created superuser: ${superUserData.name}`);
 }
 
 /**
@@ -598,6 +633,7 @@ async function seedSnapshots() {
 async function main() {
     console.log('Starting database seeding...\n');
 
+    await seedSuperUser();
     await seedUsers();
     await seedOrganizations();
     await seedOrganizationMemberships();

--- a/src/app/(web)/admin/page.tsx
+++ b/src/app/(web)/admin/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import useAdminPage from '@/lib/hooks/useAdminPage';
+
+export default function AdminPage() {
+    const { isSuperUser, isLoading } = useAdminPage();
+
+    if (isLoading) return <div>Loading...</div>;
+    if (!isSuperUser) return null;
+
+    return <div>Admin Dashboard Coming Soon</div>;
+}

--- a/src/app/(web)/crm/dashboard/page.tsx
+++ b/src/app/(web)/crm/dashboard/page.tsx
@@ -2,10 +2,13 @@
 
 import Image from 'next/image';
 import OnboardingModal from '@/lib/components/modal/OnboardingModal';
+import AdminOnboardingButton from '@/lib/components/core/AdminOnboardingButton';
 import useOnboardingState from '@/lib/hooks/useOnboardingState';
+import { useAuth } from '@/lib/auth/auth-context';
 
 export default function DashboardPage() {
     const { isOnboarding, isSignedOut, isUserLoading } = useOnboardingState();
+    const { isSuperUser } = useAuth();
 
     if (isUserLoading) return <div>Loading...</div>;
     if (isSignedOut) return <div>You must be signed in...</div>;
@@ -13,7 +16,10 @@ export default function DashboardPage() {
     return (
         <div>
             {isOnboarding ? (
-                <OnboardingModal />
+                <>
+                    <OnboardingModal />
+                    {isSuperUser && <AdminOnboardingButton />}
+                </>
             ) : (
                 <div className="flex h-screen flex-col items-center justify-center gap-6">
                     <Image

--- a/src/install/internal/ui/ui.go
+++ b/src/install/internal/ui/ui.go
@@ -239,7 +239,7 @@ func (m model) View() tea.View {
 
 	var steps string
 	if m.setupComplete {
-		steps = fmt.Sprintf("Sarge installation complete!\nYou can start using Sarge now by visiting:\n\nhttps://%s!\n", m.hostname)
+		steps = fmt.Sprintf("Sarge installation complete!\nYou can start using Sarge now by visiting:\n\n\"https://%s\"\n\nThe first account created will become the super user.", m.hostname)
 	} else {
 		steps = lipgloss.JoinVertical(lipgloss.Center, stepLines...)
 	}

--- a/src/lib/auth/auth-client.tsx
+++ b/src/lib/auth/auth-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createAuthClient } from 'better-auth/react';
-import { organizationClient } from 'better-auth/client/plugins';
+import { organizationClient, adminClient } from 'better-auth/client/plugins';
 import { ac, owner, admin, recruiter, reviewer, member } from '@/lib/auth/permissions';
 
 export const authClient = createAuthClient({
@@ -16,6 +16,7 @@ export const authClient = createAuthClient({
                 member,
             },
         }),
+        adminClient(),
     ],
 });
 

--- a/src/lib/auth/auth-client.tsx
+++ b/src/lib/auth/auth-client.tsx
@@ -2,7 +2,16 @@
 
 import { createAuthClient } from 'better-auth/react';
 import { organizationClient, adminClient } from 'better-auth/client/plugins';
-import { ac, owner, admin, recruiter, reviewer, member } from '@/lib/auth/permissions';
+import {
+    ac,
+    owner,
+    admin,
+    recruiter,
+    reviewer,
+    member,
+    adminAccessControl,
+    superuser,
+} from '@/lib/auth/permissions';
 
 export const authClient = createAuthClient({
     plugins: [
@@ -16,7 +25,10 @@ export const authClient = createAuthClient({
                 member,
             },
         }),
-        adminClient(),
+        adminClient({
+            ac: adminAccessControl,
+            roles: { superuser },
+        }),
     ],
 });
 

--- a/src/lib/auth/auth-context.tsx
+++ b/src/lib/auth/auth-context.tsx
@@ -10,7 +10,6 @@ type SessionData = {
         email: string;
         name: string;
         image?: string | null | undefined;
-        // NOTE(laith): User.role (superuser, user), NOT Memer.role (admin, reviewer, member, etc)
         role?: string | null | undefined;
     };
     session: {

--- a/src/lib/auth/auth-context.tsx
+++ b/src/lib/auth/auth-context.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useMemo } from 'react';
 import { useSession, useActiveOrganization, useActiveMember } from '@/lib/auth/auth-client';
+import { SUPER_USER_ROLE } from '@/lib/auth/permissions';
 
 type SessionData = {
     user: {
@@ -9,6 +10,8 @@ type SessionData = {
         email: string;
         name: string;
         image?: string | null | undefined;
+        // NOTE(laith): User.role (superuser, user), NOT Memer.role (admin, reviewer, member, etc)
+        role?: string | null | undefined;
     };
     session: {
         id: string;
@@ -33,6 +36,7 @@ type UserData = {
     email: string;
     name: string;
     image?: string | null | undefined;
+    role?: string | null | undefined;
 };
 
 type MemberData = {
@@ -58,6 +62,7 @@ interface AuthContextValue {
 
     isAuthenticated: boolean;
     hasActiveOrganization: boolean;
+    isSuperUser: boolean;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -95,6 +100,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
             isAuthenticated: !!session?.user,
             hasActiveOrganization: !!session?.session?.activeOrganizationId,
+            isSuperUser: session?.user?.role === SUPER_USER_ROLE,
         };
     }, [session, activeOrganization, activeMember, sessionPending, orgPending, memberPending]);
 

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -85,12 +85,12 @@ export const auth = betterAuth({
                 before: async (user) => {
                     if (hasExistingUsers) return { data: user };
 
-                    const userCount = await prisma.user.count();
-                    if (userCount > 0) {
+                    if ((await prisma.user.count()) > 0) {
                         hasExistingUsers = true;
                         return { data: user };
                     }
 
+                    // first account to sign in becomes the superuser
                     return { data: { ...user, role: SUPER_USER_ROLE } };
                 },
             },

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -1,10 +1,20 @@
 import { betterAuth } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
-import { organization } from 'better-auth/plugins';
+import { admin as adminPlugin, organization } from 'better-auth/plugins';
 import { prisma } from '@/lib/prisma';
-import { ac, owner, admin, recruiter, reviewer, member } from '@/lib/auth/permissions';
+import {
+    ac,
+    owner,
+    admin,
+    recruiter,
+    reviewer,
+    member,
+    SUPER_USER_ROLE,
+} from '@/lib/auth/permissions';
 import sesConnector from '@/lib/connectors/ses.connector';
 import { generateEmailVerificationHTML } from '@/lib/templates/emailVerification';
+
+let hasExistingUsers = false;
 
 const baseUrl =
     process.env.BETTER_AUTH_URL ??
@@ -68,6 +78,21 @@ export const auth = betterAuth({
         provider: 'postgresql',
     }),
     databaseHooks: {
+        user: {
+            create: {
+                before: async (user) => {
+                    if (hasExistingUsers) return { data: user };
+
+                    const userCount = await prisma.user.count();
+                    if (userCount > 0) {
+                        hasExistingUsers = true;
+                        return { data: user };
+                    }
+
+                    return { data: { ...user, role: SUPER_USER_ROLE } };
+                },
+            },
+        },
         session: {
             create: {
                 before: async (session) => {
@@ -155,6 +180,9 @@ export const auth = betterAuth({
                     console.error('Failed to send invitation email:', error);
                 }
             },
+        }),
+        adminPlugin({
+            adminRoles: [SUPER_USER_ROLE],
         }),
     ],
 });

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -9,6 +9,8 @@ import {
     recruiter,
     reviewer,
     member,
+    adminAccessControl,
+    superuser,
     SUPER_USER_ROLE,
 } from '@/lib/auth/permissions';
 import sesConnector from '@/lib/connectors/ses.connector';
@@ -182,6 +184,8 @@ export const auth = betterAuth({
             },
         }),
         adminPlugin({
+            ac: adminAccessControl,
+            roles: { superuser },
             adminRoles: [SUPER_USER_ROLE],
         }),
     ],

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -17,6 +17,8 @@ const statement = {
     comment: ['create', 'read', 'update', 'delete'],
 } as const;
 
+export const SUPER_USER_ROLE = 'superuser';
+
 export const ac = createAccessControl(statement);
 
 export const owner = ac.newRole({

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -5,6 +5,10 @@ import {
     adminAc,
     memberAc,
 } from 'better-auth/plugins/organization/access';
+import {
+    defaultStatements as adminDefaultStatements,
+    adminAc as baseAdminAc,
+} from 'better-auth/plugins/admin/access';
 
 const statement = {
     ...defaultStatements,
@@ -20,6 +24,13 @@ const statement = {
 export const SUPER_USER_ROLE = 'superuser';
 
 export const ac = createAccessControl(statement);
+
+// Admin plugin access control is different from the org `ac` above, since the
+// admin plugin operates on its own statement set (user, session) and resolves
+// against User.role rather than Member.role.
+export const adminAccessControl = createAccessControl(adminDefaultStatements);
+
+export const superuser = adminAccessControl.newRole({ ...baseAdminAc.statements });
 
 export const owner = ac.newRole({
     ...ownerAc.statements,

--- a/src/lib/components/core/AdminOnboardingButton.tsx
+++ b/src/lib/components/core/AdminOnboardingButton.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { ShieldUser } from 'lucide-react';
+import { Button } from '@/lib/components/ui/Button';
+
+/**
+ * z-[51] is needed bc we want the button to be above the modal layering of (z-50)
+ * we set pointer-events-auto which re-enables clicks
+ * since an open modal sets pointer-events: none on the body.
+ */
+export default function AdminOnboardingButton() {
+    const router = useRouter();
+
+    return (
+        <Button
+            variant="primary"
+            onClick={() => router.push('/admin')}
+            className="pointer-events-auto fixed bottom-6 left-6 z-[51] px-4"
+        >
+            <ShieldUser />
+            Admin
+        </Button>
+    );
+}

--- a/src/lib/components/core/AdminOnboardingButton.tsx
+++ b/src/lib/components/core/AdminOnboardingButton.tsx
@@ -4,11 +4,6 @@ import { useRouter } from 'next/navigation';
 import { ShieldUser } from 'lucide-react';
 import { Button } from '@/lib/components/ui/Button';
 
-/**
- * z-[51] is needed bc we want the button to be above the modal layering of (z-50)
- * we set pointer-events-auto which re-enables clicks
- * since an open modal sets pointer-events: none on the body.
- */
 export default function AdminOnboardingButton() {
     const router = useRouter();
 

--- a/src/lib/components/core/Sidebar.tsx
+++ b/src/lib/components/core/Sidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Home, File, Users, Settings, ChevronDown, BookOpen } from 'lucide-react';
+import { Home, File, Users, Settings, ChevronDown, BookOpen, ShieldUser } from 'lucide-react';
 import { useAuth } from '@/lib/auth/auth-context';
 import Image from 'next/image';
 import useOnboardingState from '@/lib/hooks/useOnboardingState';
@@ -791,6 +791,22 @@ export function Sidebar() {
                 </SidebarGroup>
             </SidebarContent>
             <SidebarFooter>
+                {auth.isSuperUser && (
+                    <SidebarMenu>
+                        <SidebarMenuItem>
+                            <SidebarMenuButton
+                                tooltip="Admin"
+                                className="hover:!bg-sarge-primary-100 focus:!bg-sarge-primary-200 p-2.5 transition-colors duration-600 ease-out group-data-[collapsible=icon]:!mx-auto group-data-[collapsible=icon]:!h-8 group-data-[collapsible=icon]:!w-8 group-data-[collapsible=icon]:p-0 hover:cursor-pointer"
+                                onClick={() => router.push('/admin')}
+                            >
+                                <ShieldUser className="text-sarge-gray-600 !h-4 !w-4" />
+                                <span className="text-sarge-gray-800 text-xs font-medium group-data-[collapsible=icon]:hidden">
+                                    Admin
+                                </span>
+                            </SidebarMenuButton>
+                        </SidebarMenuItem>
+                    </SidebarMenu>
+                )}
                 {canSeeSettings && (
                     <SidebarMenu>
                         <SidebarMenuItem>

--- a/src/lib/hooks/useAdminPage.ts
+++ b/src/lib/hooks/useAdminPage.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/lib/auth/auth-context';
+
+function useAdminPage() {
+    const router = useRouter();
+    const { isSuperUser, sessionPending } = useAuth();
+
+    useEffect(() => {
+        if (!sessionPending && !isSuperUser) {
+            router.replace('/crm/dashboard');
+        }
+    }, [sessionPending, isSuperUser, router]);
+
+    return {
+        isSuperUser,
+        isLoading: sessionPending,
+    };
+}
+
+export default useAdminPage;

--- a/src/lib/services/member.service.ts
+++ b/src/lib/services/member.service.ts
@@ -2,7 +2,7 @@ import type { Member, MemberWithUser } from '@/lib/types/member.types';
 import { prisma } from '@/lib/prisma';
 import { ConflictException, NotFoundException } from '@/lib/utils/errors.utils';
 import { auth } from '@/lib/auth/auth';
-import { assertPermission } from '@/lib/utils/permissions.utils';
+import { assertOrgPermission } from '@/lib/utils/permissions.utils';
 
 async function updateMemberRole(
     memberIdToUpdate: string,
@@ -10,7 +10,7 @@ async function updateMemberRole(
     organizationId: string,
     headers: Headers
 ): Promise<Member> {
-    await assertPermission(
+    await assertOrgPermission(
         headers,
         { member: ['update'] },
         'You are not an admin of this organization'

--- a/src/lib/utils/permissions.utils.ts
+++ b/src/lib/utils/permissions.utils.ts
@@ -1,5 +1,6 @@
 import { auth } from '@/lib/auth/auth';
 import { ForbiddenException } from '@/lib/utils/errors.utils';
+import { SUPER_USER_ROLE } from '@/lib/auth/permissions';
 import type { ac } from '@/lib/auth/permissions';
 
 type PermissionMap = Partial<{
@@ -50,4 +51,14 @@ export async function assertOwner(
     message = 'Owner role required'
 ): Promise<void> {
     await assertPermission(headers, { organization: ['delete'] }, message);
+}
+
+export async function assertSuperUser(
+    headers: Headers,
+    message = 'Superuser role required'
+): Promise<void> {
+    const session = await auth.api.getSession({ headers });
+    if (session?.user.role !== SUPER_USER_ROLE) {
+        throw new ForbiddenException(message);
+    }
 }

--- a/src/lib/utils/permissions.utils.ts
+++ b/src/lib/utils/permissions.utils.ts
@@ -1,15 +1,20 @@
 import { auth } from '@/lib/auth/auth';
 import { ForbiddenException } from '@/lib/utils/errors.utils';
-import { SUPER_USER_ROLE } from '@/lib/auth/permissions';
-import type { ac } from '@/lib/auth/permissions';
+import type { ac, adminAccessControl } from '@/lib/auth/permissions';
 
-type PermissionMap = Partial<{
+type OrgPermissionMap = Partial<{
     [R in keyof typeof ac.statements]: Array<(typeof ac.statements)[R][number]>;
 }>;
 
-export async function hasPermission(
+type AdminPermissionMap = Partial<{
+    [R in keyof typeof adminAccessControl.statements]: Array<
+        (typeof adminAccessControl.statements)[R][number]
+    >;
+}>;
+
+export async function hasOrgPermission(
     headers: Headers,
-    permissions: PermissionMap
+    permissions: OrgPermissionMap
 ): Promise<boolean> {
     return (
         await auth.api.hasPermission({
@@ -21,12 +26,37 @@ export async function hasPermission(
     ).success;
 }
 
-export async function assertPermission(
+export async function assertOrgPermission(
     headers: Headers,
-    permissions: PermissionMap,
+    permissions: OrgPermissionMap,
     message = 'You do not have permission to perform this action'
 ): Promise<void> {
-    const allowed = await hasPermission(headers, permissions);
+    const allowed = await hasOrgPermission(headers, permissions);
+    if (!allowed) {
+        throw new ForbiddenException(message);
+    }
+}
+
+export async function hasAdminPermission(
+    headers: Headers,
+    permissions: AdminPermissionMap
+): Promise<boolean> {
+    return (
+        await auth.api.userHasPermission({
+            headers,
+            body: {
+                permissions,
+            },
+        })
+    ).success;
+}
+
+export async function assertAdminPermission(
+    headers: Headers,
+    permissions: AdminPermissionMap,
+    message = 'Admin permission required'
+): Promise<void> {
+    const allowed = await hasAdminPermission(headers, permissions);
     if (!allowed) {
         throw new ForbiddenException(message);
     }
@@ -36,29 +66,27 @@ export async function assertRecruiterOrAbove(
     headers: Headers,
     message = 'Recruiter role or above required'
 ): Promise<void> {
-    await assertPermission(headers, { assessment: ['assign'] }, message);
+    await assertOrgPermission(headers, { assessment: ['assign'] }, message);
 }
 
 export async function assertAdminOrOwner(
     headers: Headers,
     message = 'Admin or owner role required'
 ): Promise<void> {
-    await assertPermission(headers, { organization: ['update'] }, message);
+    await assertOrgPermission(headers, { organization: ['update'] }, message);
 }
 
 export async function assertOwner(
     headers: Headers,
     message = 'Owner role required'
 ): Promise<void> {
-    await assertPermission(headers, { organization: ['delete'] }, message);
+    await assertOrgPermission(headers, { organization: ['delete'] }, message);
 }
 
 export async function assertSuperUser(
     headers: Headers,
     message = 'Superuser role required'
 ): Promise<void> {
-    const session = await auth.api.getSession({ headers });
-    if (session?.user.role !== SUPER_USER_ROLE) {
-        throw new ForbiddenException(message);
-    }
+    // This is equivalent to asserting "is the superuser". since superuser holds every admin statement.
+    await assertAdminPermission(headers, { user: ['list'] }, message);
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
-const protectedRoutes = ['/crm'];
+const protectedRoutes = ['/crm', '/admin'];
 
 function hasAuthCookie(request: NextRequest): boolean {
     return request.cookies


### PR DESCRIPTION
# [Install/CRM][Fullstack] - Sarge Admin Sign up Flow

## Changes

- Created an **admin** role in better auth called `superuser`. Admin roles live on `User.role` and NOT on `Member.role`. It is important to note that `Member.role` is the organization specific roles such as `admin`, `owner`, `reviewer`, etc. The only `User.role`s are now `superuser` and `user`.
- There is only **one** superuser created per Sarge instance. The first user who signs into Sarge will be the `superuser`.
- Stubbed out `/admin` for a future admin/moderation dashboard for this user.
    - I think it would be nice to have a route to `/admin` in the navbar available to the `superuser` in the future. Also in the onboarding flow, as that is the first thing new users see.

---

## Notes

- There are required fields necessary for this feature to work, so they have been added in `schema.prisma`, though not required to be populated until moderation is implemented.

---

## Checklist

Please go through all items before requesting reviewers:

- [x] All commits are tagged with the ticket number
- [x] No linting errors / newline warnings
- [x] All code follows repository-configured formatting
- [x] No merge conflicts
- [x] All checks passing
- [x] Screenshots included for UI changes
- [x] Remove non-applicable sections of this template
- [x] PR assigned to yourself
- [x] Reviewers requested & Slack ping sent
- [x] PR linked to the issue (fill in 'Closes #')
- [x] If design-related, notify the designer in Slack

---

## Closes

Closes #308
